### PR TITLE
Set transfer-encoding header in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ curl http://localhost:5001/streams/$STREAM_ID
 in a separate terminal, produce some data using the same stream id...
 
 ```
-$ curl http://localhost:5001/streams/$STREAM_ID -X POST
+$ curl -H "Transfer-Encoding: chunked" http://localhost:5001/streams/$STREAM_ID -X POST
 ```
 
 ...and you see the busl.


### PR DESCRIPTION
The example in the README fails for me without setting the `Transfer-Encoding` header to `chunked`.

```console
$ curl -k http://localhost:5000/streams/$STREAM_ID -X POST -d '{"test":"value"}'
A chunked Transfer-Encoding header is required.

$ curl -k http://localhost:5000/streams/$STREAM_ID -X POST -d '{"test":"value"}' -H "Transfer-Encoding:  chunked"
$ 
```