### PR TITLE
Log HTTP Port

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -183,6 +183,7 @@ func app() http.Handler {
 	return logRequest(enforceHTTPS(p.ServeHTTP))
 }
 func Start(port string, shutdown <-chan struct{}) {
+	log.Printf("http.start.port=%s\n", port)
 	http.Handle("/", app())
 	go listenForShutdown(shutdown)
 


### PR DESCRIPTION
When busl starts, it uses `$PORT` for listening to HTTP requests.
`$PORT` can be any number and is sometimes opaque. This change
provides a simple logging mechanism to see which port busl used for
HTTP requests.