### PR TITLE
io.Copy friendly spike

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Broker interface {
-	Publish(msg []byte)
+	Write(msg []byte) (int, error)
 	Subscribe() (chan []byte, error)
 	Unsubscribe(ch chan []byte)
 }

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -1,11 +1,13 @@
 package broker
 
 import (
+	"io"
+
 	"github.com/heroku/busl/util"
 )
 
 type Broker interface {
-	Write(msg []byte) (int, error)
+	io.Writer
 	Subscribe() (chan []byte, error)
 	Unsubscribe(ch chan []byte)
 }

--- a/broker/redis.go
+++ b/broker/redis.go
@@ -192,7 +192,16 @@ func (b *RedisBroker) Publish(msg []byte) {
 	b.publishOn(msg)
 }
 
-func (b *RedisBroker) publishOn(msg []byte) {
+func (b *RedisBroker) Write(msg []byte) (n int, err error) {
+	err = b.publishOn(msg)
+
+	if err != nil {
+		return 0, err
+	}
+	return len(msg), nil
+}
+
+func (b *RedisBroker) publishOn(msg []byte) error {
 	conn := redisPool.Get()
 	defer conn.Close()
 
@@ -204,10 +213,11 @@ func (b *RedisBroker) publishOn(msg []byte) {
 	appendedVals, err := redis.Values(conn.Do("EXEC"))
 	if err != nil {
 		util.CountWithData("RedisBroker.publishOn.error", 1, "error=%s", err)
+		return err
 	}
 	appendedLen := appendedVals[0].(int64)
 
-	conn.Send("PUBLISH", b.channel.id(), appendedLen)
+	return conn.Send("PUBLISH", b.channel.id(), appendedLen)
 }
 
 func (b *RedisBroker) replay(ch chan []byte) (err error) {

--- a/broker/redis.go
+++ b/broker/redis.go
@@ -188,10 +188,6 @@ func (b *RedisBroker) UnsubscribeAll() {
 	conn.Do("SETEX", b.channel.doneId(), redisChannelExpire, []byte{1})
 }
 
-func (b *RedisBroker) Publish(msg []byte) {
-	b.publishOn(msg)
-}
-
 func (b *RedisBroker) Write(msg []byte) (n int, err error) {
 	err = b.publishOn(msg)
 

--- a/broker/redis_test.go
+++ b/broker/redis_test.go
@@ -70,12 +70,12 @@ func (s *BrokerSuite) SetUpTest(c *C) {
 func (s *BrokerSuite) TestRedisSubscribe(c *C) {
 	ch, _ := s.broker.Subscribe()
 	defer s.broker.Unsubscribe(ch)
-	s.broker.Publish([]byte("busl"))
+	s.broker.Write([]byte("busl"))
 	c.Assert(string(<-ch), Equals, "busl")
 }
 
 func (s *BrokerSuite) TestRedisSubscribeReplay(c *C) {
-	s.broker.Publish([]byte("busl"))
+	s.broker.Write([]byte("busl"))
 	ch, _ := s.broker.Subscribe()
 	defer s.broker.Unsubscribe(ch)
 	c.Assert(string(<-ch), Equals, "busl")
@@ -83,7 +83,7 @@ func (s *BrokerSuite) TestRedisSubscribeReplay(c *C) {
 
 func (s *BrokerSuite) TestRedisSubscribeChannelDone(c *C) {
 	redisBroker := NewRedisBroker(s.uuid)
-	redisBroker.Publish([]byte("busl"))
+	redisBroker.Write([]byte("busl"))
 	redisBroker.UnsubscribeAll()
 
 	ch, _ := s.broker.Subscribe()

--- a/server/server.go
+++ b/server/server.go
@@ -64,32 +64,12 @@ func pub(w http.ResponseWriter, r *http.Request) {
 	bodyBuffer := bufio.NewReader(r.Body)
 	defer r.Body.Close()
 
-	buffer := make([]byte, 4096)
+	_, err := io.Copy(msgBroker, bodyBuffer)
 
-	for {
-		readLen, err := bodyBuffer.Read(buffer)
-
-		if readLen > 0 {
-			msg := make([]byte, readLen)
-			copy(msg, buffer[:readLen])
-			msgBroker.Publish(msg)
-		} else {
-			return
-		}
-
-		switch {
-		case err == io.ErrUnexpectedEOF:
-			util.CountWithData("server.pub.read.eoferror", 1, "msg=\"%v\"", err.Error())
-			return
-		case err == io.EOF:
-			return
-		case err != nil:
-			log.Printf("%#v", err)
-			http.Error(w, "Unhandled error, please try again.", http.StatusInternalServerError)
-			rollbar.Error(rollbar.ERR, fmt.Errorf("unhandled error: %#v", err))
-			return
-		}
-
+	if err != nil {
+		log.Printf("%#v", err)
+		http.Error(w, "Unhandled error, please try again.", http.StatusInternalServerError)
+		rollbar.Error(rollbar.ERR, fmt.Errorf("unhandled error: %#v", err))
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -88,7 +88,7 @@ func (s *HttpServerSuite) TestSub(c *C) {
 		sub(response, request)
 	})
 
-	publisher.Publish([]byte("busl1"))
+	publisher.Write([]byte("busl1"))
 	publisher.UnsubscribeAll()
 	<-waiter
 


### PR DESCRIPTION
Wanted to create this to initiate some conversation.

Some things that I'm not too happy with currently:

1) The error handling in publishOn in conjunction with `Write`
   Not sure if this is on purpose that we silently ignore
   the EXEC error instead of failing or not, but then rely
   on the `PUBLISH` call (but also silently ignore the error
   return value there)

2) Potentially making msgBroker more of an io.Reader / io.Writer
   and dropping some of the function calls (if they are deemed
   unnecessary)