### PR TITLE
Don't authenticate POST /streams/<id> requests

### DIFF
--- a/broker/io.go
+++ b/broker/io.go
@@ -13,9 +13,13 @@ type writer struct {
 	channel channel
 }
 
-var errNotRegistered = errors.New("Channel is not registered.")
+var ErrNotRegistered = errors.New("Channel is not registered.")
 
 func NewWriter(uuid util.UUID) (io.WriteCloser, error) {
+	if !NewRedisRegistrar().IsRegistered(uuid) {
+		return nil, ErrNotRegistered
+	}
+
 	return &writer{channel(uuid)}, nil
 }
 
@@ -55,7 +59,7 @@ type reader struct {
 
 func NewReader(uuid util.UUID) (io.ReadCloser, error) {
 	if !NewRedisRegistrar().IsRegistered(uuid) {
-		return nil, errNotRegistered
+		return nil, ErrNotRegistered
 	}
 
 	psc := redis.PubSubConn{redisPool.Get()}

--- a/broker/redis_test.go
+++ b/broker/redis_test.go
@@ -49,11 +49,11 @@ func (s *RegistrarSuite) TestUnregisteredErrNotRegistered(c *C) {
 	// Only complains for a Reader; existing behavior allows
 	// publishers to create a channel on the fly.
 	_, err := NewReader(s.uuid)
-	c.Assert(err, Equals, errNotRegistered)
+	c.Assert(err, Equals, ErrNotRegistered)
 
 	// Writers can choose any ID it wants without consequence.
 	_, err = NewWriter(s.uuid)
-	c.Assert(err, IsNil)
+	c.Assert(err, Equals, ErrNotRegistered)
 }
 
 func (s *RegistrarSuite) TestRegisteredNoError(c *C) {

--- a/server/errors.go
+++ b/server/errors.go
@@ -14,7 +14,7 @@ func handleError(w http.ResponseWriter, r *http.Request, err error) {
 			message = assets.HttpCatGone
 		}
 
-		http.Error(w, message, http.StatusGone)
+		http.Error(w, message, http.StatusNotFound)
 
 	} else if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/server/errors.go
+++ b/server/errors.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/heroku/busl/assets"
+	"github.com/heroku/busl/broker"
+)
+
+func handleError(w http.ResponseWriter, r *http.Request, err error) {
+	if err == broker.ErrNotRegistered {
+		message := "Channel is not registered."
+		if r.Header.Get("Accept") == "text/ascii; version=feral" {
+			message = assets.HttpCatGone
+		}
+
+		http.Error(w, message, http.StatusGone)
+
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/braintree/manners"
 	"github.com/cyberdelia/pat"
-	"github.com/heroku/busl/assets"
 	"github.com/heroku/busl/broker"
 	"github.com/heroku/busl/sse"
 	"github.com/heroku/busl/util"
@@ -60,7 +59,7 @@ func pub(w http.ResponseWriter, r *http.Request) {
 
 	writer, err := broker.NewWriter(uuid)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		handleError(w, r, err)
 		return
 	}
 	defer writer.Close()
@@ -93,18 +92,10 @@ func sub(w http.ResponseWriter, r *http.Request) {
 	uuid := util.UUID(r.URL.Query().Get(":uuid"))
 
 	rd, err := broker.NewReader(uuid)
-
 	if err != nil {
-		message := "Channel is not registered."
-		if r.Header.Get("Accept") == "text/ascii; version=feral" {
-			message = assets.HttpCatGone
-		}
-
-		http.Error(w, message, http.StatusGone)
-		f.Flush()
+		handleError(w, r, err)
 		return
 	}
-
 	defer rd.Close()
 
 	// Get the offset from Last-Event-ID: or Range:

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -61,7 +61,7 @@ func (s *HttpServerSuite) Test410(c *C) {
 
 	sub(response, request)
 
-	c.Assert(response.Code, Equals, http.StatusGone)
+	c.Assert(response.Code, Equals, http.StatusNotFound)
 	c.Assert(response.Body.String(), Equals, "Channel is not registered.\n")
 }
 
@@ -72,7 +72,7 @@ func (s *HttpServerSuite) TestPubNotRegistered(c *C) {
 
 	pub(response, request)
 
-	c.Assert(response.Code, Equals, http.StatusGone)
+	c.Assert(response.Code, Equals, http.StatusNotFound)
 }
 
 func (s *HttpServerSuite) TestPubWithoutTransferEncoding(c *C) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -55,7 +55,8 @@ func (s *HttpServerSuite) TestMkstream(c *C) {
 }
 
 func (s *HttpServerSuite) Test410(c *C) {
-	request := newRequest("GET", "/streams/_1234", "")
+	streamId, _ := util.NewUUID()
+	request := newRequest("GET", "/streams/"+string(streamId), "")
 	response := CloseNotifierRecorder{httptest.NewRecorder(), make(chan bool, 1)}
 
 	sub(response, request)
@@ -64,13 +65,14 @@ func (s *HttpServerSuite) Test410(c *C) {
 	c.Assert(response.Body.String(), Equals, "Channel is not registered.\n")
 }
 
-func (s *HttpServerSuite) TestPub(c *C) {
-	request := newRequest("POST", "/streams/1234", "")
+func (s *HttpServerSuite) TestPubNotRegistered(c *C) {
+	streamId, _ := util.NewUUID()
+	request := newRequest("POST", "/streams/"+string(streamId), "")
 	response := httptest.NewRecorder()
 
 	pub(response, request)
 
-	c.Assert(response.Code, Equals, http.StatusOK)
+	c.Assert(response.Code, Equals, http.StatusGone)
 }
 
 func (s *HttpServerSuite) TestPubWithoutTransferEncoding(c *C) {


### PR DESCRIPTION
- Only authenticate the stream creation endpoint (`POST /streams`)
- Return 410 if an attempt to publish to a non registered channel happens
