### PR TITLE
Delay expiration of streams that are not producing

### DIFF
--- a/broker/io.go
+++ b/broker/io.go
@@ -165,6 +165,7 @@ func (r *reader) fetch() ([]byte, error) {
 	conn.Send("MULTI")
 	conn.Send("GETRANGE", r.channel.id(), r.offset, -1)
 	conn.Send("EXISTS", r.channel.doneId())
+	conn.Send("EXPIRE", r.channel.id(), redisChannelExpire)
 
 	list, err := redis.Values(conn.Do("EXEC"))
 	data, err := redis.Bytes(list[0], err)


### PR DESCRIPTION
To reproduce:

- You need to have a build which produces output in long
  increments (e.g. every 5 minutes)
- What happens: the channel will show up as `Channel not registered`.