### PR TITLE
Read buffer fix

### DIFF
--- a/broker/io.go
+++ b/broker/io.go
@@ -55,6 +55,7 @@ type reader struct {
 	replayed bool
 	closed   bool
 	mutex    *sync.Mutex
+	buffered bool
 }
 
 func NewReader(key string) (io.ReadCloser, error) {
@@ -119,15 +120,17 @@ func (r *reader) replay(p []byte) (n int, err error) {
 	var buf []byte
 
 	if !r.replayed {
-		r.replayed = true
-
-		buf, err = r.fetch()
+		buf, err = r.fetch(len(p))
 		n = len(buf)
 
 		if n > 0 {
 			r.offset += int64(n)
 			copy(p, buf)
 		}
+
+		// Only mark as fully replayed if
+		// we're no longer in buffered state.
+		r.replayed = !r.buffered
 
 		if err == io.EOF {
 			util.Count("RedisBroker.replay.channelDone")
@@ -158,20 +161,26 @@ func (r *reader) read(msg redis.PMessage, p []byte) (n int, err error) {
 	return n, err
 }
 
-func (r *reader) fetch() ([]byte, error) {
+func (r *reader) fetch(length int) ([]byte, error) {
 	conn := redisPool.Get()
 	defer conn.Close()
 
+	lower, upper := r.offset, r.offset+int64(length)
+
 	conn.Send("MULTI")
-	conn.Send("GETRANGE", r.channel.id(), r.offset, -1)
+	conn.Send("GETRANGE", r.channel.id(), lower, upper-1)
+	conn.Send("STRLEN", r.channel.id())
 	conn.Send("EXISTS", r.channel.doneId())
 	conn.Send("EXPIRE", r.channel.id(), redisChannelExpire)
 
 	list, err := redis.Values(conn.Do("EXEC"))
 	data, err := redis.Bytes(list[0], err)
-	done, err := redis.Bool(list[1], err)
+	size, err := redis.Int64(list[1], err)
+	done, err := redis.Bool(list[2], err)
 
-	if done {
+	if size > upper {
+		r.buffered = true
+	} else if done {
 		err = io.EOF
 	}
 

--- a/broker/io.go
+++ b/broker/io.go
@@ -143,7 +143,7 @@ func (r *reader) replay(p []byte) (n int, err error) {
 func (r *reader) read(msg redis.PMessage, p []byte) (n int, err error) {
 	var buf []byte
 
-	if msg.Channel == r.channel.id() {
+	if msg.Channel == r.channel.killId() || msg.Channel == r.channel.id() {
 		buf, err = r.fetch()
 
 		if n = len(buf); n > 0 {

--- a/broker/redis.go
+++ b/broker/redis.go
@@ -70,7 +70,7 @@ func (c channel) id() string {
 }
 
 func (c channel) wildcardId() string {
-	return string(c) + "*"
+	return string(c) + ":*"
 }
 
 func (c channel) doneId() string {


### PR DESCRIPTION
A bit overdue. This fixes certain panics that happen if the data > 32768 (the length of the allocated buffer in io.Copy).

