### PR TITLE
Extend channel expiry to 1 hour

### DIFF
--- a/broker/io.go
+++ b/broker/io.go
@@ -28,6 +28,7 @@ func (w *writer) Close() error {
 	defer conn.Close()
 
 	conn.Send("MULTI")
+	conn.Send("EXPIRE", w.channel.id(), redisKeyExpire)
 	conn.Send("SETEX", w.channel.doneId(), redisChannelExpire, []byte{1})
 	conn.Send("PUBLISH", w.channel.killId(), 1)
 	_, err := conn.Do("EXEC")

--- a/broker/redis.go
+++ b/broker/redis.go
@@ -16,7 +16,7 @@ var (
 	redisServer        *url.URL
 	redisPool          *redis.Pool
 	redisKeyExpire     = 60 // redis uses seconds for EXPIRE
-	redisChannelExpire = redisKeyExpire * 5
+	redisChannelExpire = redisKeyExpire * 60
 )
 
 func init() {


### PR DESCRIPTION
For streams explicitly closed (a.k.a marked by the publisher
as done), we expire them a minute after (which should mean
that it's already in S3 by that time).

For long running streams, this means that busl should be able
to persist in S3 when the connection breaks (busl ELB idle timeout
is set to 900s, so this should take effect sooner than the 3600s
timeout)