### PR TITLE
Make requests logging closer to the platform router's format

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -51,7 +51,7 @@ func auth(fn http.HandlerFunc) http.HandlerFunc {
 
 func logRequest(fn http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		logger := util.NewResponseLogger(w, r.URL.Path, r.UserAgent(), requestID(r))
+		logger := util.NewResponseLogger(r, w)
 		fn(logger, r)
 		logger.WriteLog()
 	}
@@ -67,24 +67,6 @@ func addDefaultHeaders(fn http.HandlerFunc) http.HandlerFunc {
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		fn(w, r)
 	}
-}
-
-func requestID(r *http.Request) (id string) {
-	if id = r.Header.Get("Request-Id"); id == "" {
-		id = r.Header.Get("X-Request-Id")
-	}
-
-	if id == "" {
-		// In the event of a rare case where uuid
-		// generation fails, it's probably more
-		// desirable to continue as is with an empty
-		// request_id than to bubble the error up the
-		// stack.
-		uuid, _ := util.NewUUID()
-		id = string(uuid)
-	}
-
-	return id
 }
 
 func offset(r *http.Request) int64 {

--- a/util/response_logger.go
+++ b/util/response_logger.go
@@ -7,16 +7,14 @@ import (
 )
 
 // NewResponseLogger creates a new logger for HTTP responses
-func NewResponseLogger(w http.ResponseWriter, path string, userAgent string, requestID string) *responseLogger {
-	return &responseLogger{ResponseWriter: w, status: http.StatusOK, path: path, userAgent: userAgent, requestID: requestID}
+func NewResponseLogger(r *http.Request, w http.ResponseWriter) *responseLogger {
+	return &responseLogger{ResponseWriter: w, request: r, status: http.StatusOK}
 }
 
 type responseLogger struct {
 	http.ResponseWriter
-	status    int
-	path      string
-	userAgent string
-	requestID string
+	request *http.Request
+	status  int
 }
 
 func (l *responseLogger) WriteHeader(s int) {
@@ -32,7 +30,27 @@ func (l *responseLogger) Flush() {
 	l.ResponseWriter.(http.Flusher).Flush()
 }
 
+func (l *responseLogger) requestID() (id string) {
+	if id = l.request.Header.Get("Request-Id"); id == "" {
+		id = l.request.Header.Get("X-Request-Id")
+	}
+
+	if id == "" {
+		// In the event of a rare case where uuid
+		// generation fails, it's probably more
+		// desirable to continue as is with an empty
+		// request_id than to bubble the error up the
+		// stack.
+		uuid, _ := NewUUID()
+		id = string(uuid)
+	}
+
+	return id
+}
+
 func (l *responseLogger) WriteLog() {
 	maskedStatus := strconv.Itoa(l.status/100) + "xx"
-	log.Printf("count#http.status.%s=1 status=%d path=%s user_agent=\"%s\" request_id=%s", maskedStatus, l.status, l.path, l.userAgent, l.requestID)
+	log.Printf("count#http.status.%s=1 request_id=%s", maskedStatus, l.requestID())
+	log.Printf("method=%s path=\"%s\" host=\"%s\" fwd=\"%s\" status=%d user_agent=\"%s\" request_id=%s",
+		l.request.Method, l.request.URL.Path, l.request.Host, l.request.Header.Get("X-Forwarded-For"), l.status, l.request.UserAgent(), l.requestID())
 }


### PR DESCRIPTION
* Send the count in another log entry.
* Log all the data we can have, so we respect as much as possible the [router log format](https://devcenter.heroku.com/articles/http-routing#heroku-router-log-format).