### PR TITLE
Add Access-Control-Expose-Headers.

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -64,6 +64,7 @@ func addDefaultHeaders(fn http.HandlerFunc) http.HandlerFunc {
 		}
 		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token")
+		w.Header().Set("Access-Control-Expose-Headers", "Cache-Control, Content-Type, Expires, Last-Modified")
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		fn(w, r)
 	}


### PR DESCRIPTION
I believe the lack of this header is preventing iOS clients from streaming.
Inspecting an iOS dashboard session shows us sending back `Content-Type:
text/event-stream`, but iOS Safari complains that the returned response was
`Content-Type: text/plain`.

I cribbed the actual list from API.