### PR TITLE
Reconnect: handle ranges for text seeders too

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ busl - the bustle part of hustle.
 
 a simple pubsub service that runs on Heroku.
 
-## usage
+## Usage
+
+### Creating streams
 
 create a stream:
 
@@ -14,6 +16,8 @@ $ export STREAM_ID=$(curl http://localhost:5001/streams -X POST)
 # STREAM_ID=b7e586c8404b74e1805f5a9543bc516f
 ```
 
+### Subscribe
+
 connect a consumer using the stream id:
 
 ```
@@ -21,6 +25,19 @@ $ curl http://localhost:5001/streams/$STREAM_ID
 ...
 ```
 
+#### Disconnections
+
+Subscribers can sometimes get disconnected. If the instance is cycled or deployed for example.
+When this happens, you can specify a `Range` header specifying which where your streaming stopped.
+
+```
+$ curl http://localhost:5001/streams/$STREAM_ID -H "Range: 100-"
+```
+
+SSE connections also handle the `Last-Event-ID` header.
+
+
+### Publish
 in a separate terminal, produce some data using the same stream id...
 
 ```
@@ -29,7 +46,7 @@ $ curl -H "Transfer-Encoding: chunked" http://localhost:5001/streams/$STREAM_ID 
 
 ...and you see the busl.
 
-## setup
+## Setup
 
 to setup to test and run busl, setup [godep](http://godoc.org/github.com/tools/godep)
 and then:
@@ -38,7 +55,7 @@ and then:
 $ make setup
 ```
 
-## test
+## Test
 
 to run tests:
 
@@ -46,7 +63,7 @@ to run tests:
 $ make test
 ```
 
-## run
+## Run
 
 to run the server:
 
@@ -54,11 +71,11 @@ to run the server:
 $ make web
 ```
 
-## deploy
+## Deploy
 
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
-## docker setup
+## Docker setup
 
 ```sh
 # Start

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Subscribers can sometimes get disconnected. If the instance is cycled or deploye
 When this happens, you can specify a `Range` header specifying which where your streaming stopped.
 
 ```
-$ curl http://localhost:5001/streams/$STREAM_ID -H "Range: 100-"
+$ curl http://localhost:5001/streams/$STREAM_ID -H "Range: bytes=100-"
 ```
 
 SSE connections also handle the `Last-Event-ID` header.

--- a/encoders/main.go
+++ b/encoders/main.go
@@ -1,6 +1,0 @@
-package encoders
-
-type Encoder interface {
-	Seek(offset int64, whence int) (int64, error)
-	Read(p []byte) (int, error)
-}

--- a/encoders/main.go
+++ b/encoders/main.go
@@ -1,0 +1,6 @@
+package encoders
+
+type Encoder interface {
+	Seek(offset int64, whence int) (int64, error)
+	Read(p []byte) (int, error)
+}

--- a/encoders/sse.go
+++ b/encoders/sse.go
@@ -17,7 +17,7 @@ type sseEncoder struct {
 }
 
 // NewSSEEncoder creates a new server-sent event encoder
-func NewSSEEncoder(r io.Reader) Encoder {
+func NewSSEEncoder(r io.Reader) io.ReadSeeker {
 	return &sseEncoder{reader: r}
 }
 

--- a/encoders/sse.go
+++ b/encoders/sse.go
@@ -2,6 +2,7 @@ package encoders
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -28,6 +29,10 @@ func (r *sseEncoder) Seek(offset int64, whence int) (n int64, err error) {
 		// The underlying reader doesn't support seeking, but
 		// we should still update the offset so the IDs will
 		// properly reflect the adjusted offset.
+
+		if whence != io.SeekStart {
+			return 0, errors.New("Only SeekStart is supported")
+		}
 		r.offset += offset
 	}
 

--- a/encoders/sse.go
+++ b/encoders/sse.go
@@ -17,7 +17,7 @@ type sseEncoder struct {
 }
 
 // NewSSEEncoder creates a new server-sent event encoder
-func NewSSEEncoder(r io.Reader) io.Reader {
+func NewSSEEncoder(r io.Reader) Encoder {
 	return &sseEncoder{reader: r}
 }
 

--- a/encoders/sse_test.go
+++ b/encoders/sse_test.go
@@ -32,7 +32,7 @@ func TestSSENoNewline(t *testing.T) {
 	for _, data := range testSSEData {
 		r := strings.NewReader(data.input)
 		enc := NewSSEEncoder(r)
-		enc.(io.Seeker).Seek(data.offset, 0)
+		enc.Seek(data.offset, 0)
 		assert.Equal(t, data.output, readstring(enc))
 	}
 }
@@ -48,7 +48,7 @@ func TestSSENonSeekableReader(t *testing.T) {
 	lr := io.LimitReader(r, 11)
 
 	enc := NewSSEEncoder(lr)
-	enc.(io.Seeker).Seek(10, 0)
+	enc.Seek(10, 0)
 
 	// `id` should be 11 even though the underlying
 	// reader wasn't seeked at all.

--- a/encoders/sse_test.go
+++ b/encoders/sse_test.go
@@ -48,7 +48,7 @@ func TestSSENonSeekableReader(t *testing.T) {
 	lr := io.LimitReader(r, 11)
 
 	enc := NewSSEEncoder(lr)
-	enc.Seek(10, 0)
+	enc.Seek(10, io.SeekStart)
 
 	// `id` should be 11 even though the underlying
 	// reader wasn't seeked at all.

--- a/encoders/sse_test.go
+++ b/encoders/sse_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type table struct {
+type sseTable struct {
 	offset int64
 	input  string
 	output string
 }
 
 var (
-	testdata = []table{
+	testSSEData = []sseTable{
 		{0, "hello", "id: 5\ndata: hello\n\n"},
 		{0, "hello\n", "id: 6\ndata: hello\ndata: \n\n"},
 		{0, "hello\nworld", "id: 11\ndata: hello\ndata: world\n\n"},
@@ -28,8 +28,8 @@ var (
 	}
 )
 
-func TestNoNewline(t *testing.T) {
-	for _, data := range testdata {
+func TestSSENoNewline(t *testing.T) {
+	for _, data := range testSSEData {
 		r := strings.NewReader(data.input)
 		enc := NewSSEEncoder(r)
 		enc.(io.Seeker).Seek(data.offset, 0)
@@ -37,7 +37,7 @@ func TestNoNewline(t *testing.T) {
 	}
 }
 
-func TestNonSeekableReader(t *testing.T) {
+func TestSSENonSeekableReader(t *testing.T) {
 	// Seek the underlying reader before
 	// passing to LimitReader: comparably similar
 	// to scenario when reading from an http.Response

--- a/encoders/text.go
+++ b/encoders/text.go
@@ -8,7 +8,7 @@ type textEncoder struct {
 }
 
 // NewTextEncoder creates a text events encoder
-func NewTextEncoder(r io.Reader) Encoder {
+func NewTextEncoder(r io.Reader) io.ReadSeeker {
 	return &textEncoder{Reader: r}
 }
 

--- a/encoders/text.go
+++ b/encoders/text.go
@@ -1,6 +1,9 @@
 package encoders
 
-import "io"
+import (
+	"errors"
+	"io"
+)
 
 type textEncoder struct {
 	io.Reader       // stores the original reader
@@ -19,6 +22,10 @@ func (r *textEncoder) Seek(offset int64, whence int) (n int64, err error) {
 		// The underlying reader doesn't support seeking, but
 		// we should still update the offset so the IDs will
 		// properly reflect the adjusted offset.
+
+		if whence != io.SeekStart {
+			return 0, errors.New("Only SeekStart is supported")
+		}
 		r.offset += offset
 	}
 

--- a/encoders/text.go
+++ b/encoders/text.go
@@ -1,0 +1,26 @@
+package encoders
+
+import "io"
+
+type textEncoder struct {
+	io.Reader       // stores the original reader
+	offset    int64 // offset for Seek purposes
+}
+
+// NewTextEncoder creates a text events encoder
+func NewTextEncoder(r io.Reader) Encoder {
+	return &textEncoder{Reader: r}
+}
+
+func (r *textEncoder) Seek(offset int64, whence int) (n int64, err error) {
+	if seeker, ok := r.Reader.(io.ReadSeeker); ok {
+		r.offset, err = seeker.Seek(offset, whence)
+	} else {
+		// The underlying reader doesn't support seeking, but
+		// we should still update the offset so the IDs will
+		// properly reflect the adjusted offset.
+		r.offset += offset
+	}
+
+	return r.offset, err
+}

--- a/encoders/text_test.go
+++ b/encoders/text_test.go
@@ -31,7 +31,7 @@ func TestTextNoNewline(t *testing.T) {
 	for _, data := range testTextData {
 		r := strings.NewReader(data.input)
 		enc := NewTextEncoder(r)
-		enc.(io.Seeker).Seek(data.offset, 0)
+		enc.Seek(data.offset, 0)
 		assert.Equal(t, data.output, readstring(enc))
 	}
 }
@@ -47,7 +47,7 @@ func TestTextNonSeekableReader(t *testing.T) {
 	lr := io.LimitReader(r, 11)
 
 	enc := NewTextEncoder(lr)
-	enc.(io.Seeker).Seek(10, 0)
+	enc.Seek(10, 0)
 
 	// `id` should be 11 even though the underlying
 	// reader wasn't seeked at all.

--- a/encoders/text_test.go
+++ b/encoders/text_test.go
@@ -1,0 +1,55 @@
+package encoders
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type textTable struct {
+	offset int64
+	input  string
+	output string
+}
+
+var (
+	testTextData = []textTable{
+		{0, "hello", "hello"},
+		{0, "hello\n", "hello\n"},
+		{0, "hello\nworld", "hello\nworld"},
+		{0, "hello\nworld\n", "hello\nworld\n"},
+		{1, "hello\nworld\n", "ello\nworld\n"},
+		{6, "hello\nworld\n", "world\n"},
+		{11, "hello\nworld\n", "\n"},
+		{12, "hello\nworld\n", ""},
+	}
+)
+
+func TestTextNoNewline(t *testing.T) {
+	for _, data := range testTextData {
+		r := strings.NewReader(data.input)
+		enc := NewTextEncoder(r)
+		enc.(io.Seeker).Seek(data.offset, 0)
+		assert.Equal(t, data.output, readstring(enc))
+	}
+}
+
+func TestTextNonSeekableReader(t *testing.T) {
+	// Seek the underlying reader before
+	// passing to LimitReader: comparably similar
+	// to scenario when reading from an http.Response
+	r := strings.NewReader("hello world")
+	r.Seek(10, 0)
+
+	// Use LimitReader to hide the Seeker interface
+	lr := io.LimitReader(r, 11)
+
+	enc := NewTextEncoder(lr)
+	enc.(io.Seeker).Seek(10, 0)
+
+	// `id` should be 11 even though the underlying
+	// reader wasn't seeked at all.
+	assert.Equal(t, "d", readstring(enc))
+}

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -140,7 +140,7 @@ func (s *Server) newReader(w http.ResponseWriter, r *http.Request) (io.ReadClose
 		return nil, errNoContent
 	}
 
-	var encoder encoders.Encoder
+	var encoder io.ReadSeeker
 	if r.Header.Get("Accept") == "text/event-stream" {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -153,7 +153,7 @@ func (s *Server) newReader(w http.ResponseWriter, r *http.Request) (io.ReadClose
 		encoder = encoders.NewTextEncoder(rd)
 	}
 
-	encoder.(io.Seeker).Seek(offset(r), 0)
+	encoder.Seek(offset(r), 0)
 	rd = ioutil.NopCloser(encoder)
 
 	done := w.(http.CloseNotifier).CloseNotify()

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -77,7 +77,7 @@ func offset(r *http.Request) (int64, error) {
 	if off = r.Header.Get("last-event-id"); off == "" {
 		if val := r.Header.Get("Range"); val != "" {
 			d := strings.SplitN(val, "=", 2)
-			if d[0] != "bytes" {
+			if d[0] != "bytes" && len(d) == 2 {
 				return 0, errors.New("HTTP 416: Invalid Range")
 			}
 			tuple := strings.SplitN(d[1], "-", 2)


### PR DESCRIPTION
This adds handling of ranges for non-SSE (plain text) seeders as well, so subscribers can handle reconnections.
This was handled for SSE connections already.