### PR TITLE
Give more meaningful names to the endpoint methods

### DIFF
--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -13,7 +13,7 @@ import (
 	"github.com/heroku/rollbar"
 )
 
-func (s *Server) put(w http.ResponseWriter, r *http.Request) {
+func (s *Server) createStream(w http.ResponseWriter, r *http.Request) {
 	registrar := broker.NewRedisRegistrar()
 
 	if err := registrar.Register(key(r)); err != nil {
@@ -30,7 +30,7 @@ func (s *Server) health(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "OK")
 }
 
-func (s *Server) pub(w http.ResponseWriter, r *http.Request) {
+func (s *Server) publish(w http.ResponseWriter, r *http.Request) {
 	if !util.StringInSlice(r.TransferEncoding, "chunked") {
 		http.Error(w, "A chunked Transfer-Encoding header is required.", http.StatusBadRequest)
 		return
@@ -71,7 +71,7 @@ func (s *Server) pub(w http.ResponseWriter, r *http.Request) {
 	go storeOutput(key(r), requestURI(r), s.StorageBaseURL)
 }
 
-func (s *Server) sub(w http.ResponseWriter, r *http.Request) {
+func (s *Server) subscribe(w http.ResponseWriter, r *http.Request) {
 	if _, ok := w.(http.Flusher); !ok {
 		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -55,9 +55,9 @@ func (s *Server) router() http.Handler {
 
 	r.HandleFunc("/health", s.addDefaultHeaders(s.health))
 
-	r.HandleFunc("/streams/{key:.+}", s.addDefaultHeaders(s.sub)).Methods("GET")
-	r.HandleFunc("/streams/{key:.+}", s.addDefaultHeaders(s.pub)).Methods("POST")
-	r.HandleFunc("/streams/{key:.+}", s.auth(s.addDefaultHeaders(s.put))).Methods("PUT")
+	r.HandleFunc("/streams/{key:.+}", s.addDefaultHeaders(s.subscribe)).Methods("GET")
+	r.HandleFunc("/streams/{key:.+}", s.addDefaultHeaders(s.publish)).Methods("POST")
+	r.HandleFunc("/streams/{key:.+}", s.auth(s.addDefaultHeaders(s.createStream))).Methods("PUT")
 
 	return logRequest(s.enforceHTTPS(r.ServeHTTP))
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -27,7 +27,7 @@ func Test410(t *testing.T) {
 	request, _ := http.NewRequest("GET", "/streams/"+streamID, nil)
 	response := httptest.NewRecorder()
 
-	baseServer.sub(response, request)
+	baseServer.subscribe(response, request)
 
 	assert.Equal(t, response.Code, http.StatusNotFound)
 	assert.Equal(t, response.Body.String(), "Channel is not registered.\n")
@@ -39,7 +39,7 @@ func TestPubNotRegistered(t *testing.T) {
 	request.TransferEncoding = []string{"chunked"}
 	response := httptest.NewRecorder()
 
-	baseServer.pub(response, request)
+	baseServer.publish(response, request)
 
 	assert.Equal(t, response.Code, http.StatusNotFound)
 }
@@ -48,7 +48,7 @@ func TestPubWithoutTransferEncoding(t *testing.T) {
 	request, _ := http.NewRequest("POST", "/streams/1234", nil)
 	response := httptest.NewRecorder()
 
-	baseServer.pub(response, request)
+	baseServer.publish(response, request)
 
 	assert.Equal(t, response.Code, http.StatusBadRequest)
 	assert.Equal(t, response.Body.String(), "A chunked Transfer-Encoding header is required.\n")


### PR DESCRIPTION
Extracted out of #91.