### PR TITLE
Make sure we return a 404 if trying to publish on a closed feed

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -44,6 +44,25 @@ func TestPubNotRegistered(t *testing.T) {
 	assert.Equal(t, response.Code, http.StatusNotFound)
 }
 
+func TestPubClosed(t *testing.T) {
+	uuid, _ := util.NewUUID()
+
+	registrar := broker.NewRedisRegistrar()
+	err := registrar.Register(uuid)
+	assert.Nil(t, err)
+	writer, err := broker.NewWriter(uuid)
+	assert.Nil(t, err)
+	writer.Close()
+
+	request, _ := http.NewRequest("POST", "/streams/"+uuid, nil)
+	request.TransferEncoding = []string{"chunked"}
+	response := httptest.NewRecorder()
+
+	baseServer.publish(response, request)
+
+	assert.Equal(t, response.Code, http.StatusNotFound)
+}
+
 func TestPubWithoutTransferEncoding(t *testing.T) {
 	request, _ := http.NewRequest("POST", "/streams/1234", nil)
 	response := httptest.NewRecorder()


### PR DESCRIPTION
There is no behavior change here. Just adding a test making sure trying to publish on a closed feed is impossible.