### PR TITLE
Only close the writer if it didn't finish with an error

### DIFF
--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -41,7 +41,6 @@ func (s *Server) publish(w http.ResponseWriter, r *http.Request) {
 		handleError(w, r, err)
 		return
 	}
-	defer writer.Close()
 
 	body := bufio.NewReader(r.Body)
 	defer r.Body.Close()
@@ -80,6 +79,7 @@ func (s *Server) publish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	writer.Close()
 	// Asynchronously upload the output to our defined storage backend.
 	go storeOutput(key(r), requestURI(r), s.StorageBaseURL)
 }


### PR DESCRIPTION
When getting an unexpectedEOF, or any connection error, we shouldn't close the stream.