### PR TITLE
Handle logging nil errors

### DIFF
--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -61,13 +61,13 @@ func (s *Server) publish(w http.ResponseWriter, r *http.Request) {
 	_, err = io.Copy(writer, body)
 
 	if err == io.ErrUnexpectedEOF {
-		util.CountWithData("server.pub.read.eoferror", 1, "msg=\"%v\" request_id=%q", err.Error(), r.Header.Get("Request-Id"))
+		util.CountWithData("server.pub.read.eoferror", 1, "msg=%q request_id=%q", err, r.Header.Get("Request-Id"))
 		return
 	}
 
 	netErr, ok := err.(net.Error)
 	if ok && netErr.Timeout() {
-		util.CountWithData("server.pub.read.timeout", 1, "msg=\"%v\" request_id=%q", err.Error(), r.Header.Get("Request-Id"))
+		util.CountWithData("server.pub.read.timeout", 1, "msg=%q request_id=%q", err, r.Header.Get("Request-Id"))
 		handleError(w, r, netErr)
 		return
 	}
@@ -103,12 +103,12 @@ func (s *Server) subscribe(w http.ResponseWriter, r *http.Request) {
 
 	netErr, ok := err.(net.Error)
 	if ok && netErr.Timeout() {
-		util.CountWithData("server.sub.read.timeout", 1, "msg=\"%v\" request_id=%q", err.Error(), r.Header.Get("Request-Id"))
+		util.CountWithData("server.sub.read.timeout", 1, "msg=%q request_id=%q", err, r.Header.Get("Request-Id"))
 		return
 	}
 
 	if err != nil {
 		rollbar.Error(rollbar.ERR, fmt.Errorf("unhandled error: %#v", err))
 	}
-	util.CountWithData("server.sub.read.finish", 1, "msg=\"%v\" request_id=%q", err.Error(), r.Header.Get("Request-Id"))
+	util.CountWithData("server.sub.read.finish", 1, "msg=%q request_id=%q", err, r.Header.Get("Request-Id"))
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -125,6 +125,7 @@ func TestPubSub(t *testing.T) {
 		resp, err = http.Get(server.URL + "/streams/" + uuid)
 		defer resp.Body.Close()
 		assert.Nil(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
 
 		body, _ := ioutil.ReadAll(resp.Body)
 		assert.Equal(t, body, expected)
@@ -355,6 +356,7 @@ func TestSubGoneWithBackend(t *testing.T) {
 	resp, err := http.Get(server.URL + "/streams/" + uuid)
 	defer resp.Body.Close()
 	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
 
 	body, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, body, []byte("hello world"))


### PR DESCRIPTION
Specifically, `server.sub.read.finish` is more likely to have a `nil` error than not.