### PR TITLE
Change body reader approach

### DIFF
--- a/busltee/runner_test.go
+++ b/busltee/runner_test.go
@@ -112,7 +112,7 @@ func TestRun(t *testing.T) {
 	select {
 	case result := <-post:
 		if string(result) != "hello" {
-			t.Fatalf("Expected POST body to be `hello`, got %s", result)
+			t.Fatalf("Expected POST body to be `hello`, got %q", result)
 		}
 	case <-time.After(1 * time.Second):
 		t.Fatalf("POST channel got no response")

--- a/busltee/transport.go
+++ b/busltee/transport.go
@@ -34,10 +34,10 @@ func (t *Transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 
 	go func() {
 		defer tmpFile.Close()
+		defer t.Close()
 
 		tee := io.TeeReader(req.Body, tmpFile)
 		_, err := ioutil.ReadAll(tee)
-		t.Close()
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/busltee/transport.go
+++ b/busltee/transport.go
@@ -1,13 +1,13 @@
 package busltee
 
 import (
-	"bytes"
 	"errors"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -19,8 +19,9 @@ type Transport struct {
 	Transport     http.RoundTripper
 	SleepDuration time.Duration
 
-	body   io.ReadCloser
-	buffer *os.File
+	bufferName string
+	mutex      *sync.Mutex
+	closed     bool
 }
 
 func (t *Transport) RoundTrip(req *http.Request) (res *http.Response, err error) {
@@ -28,9 +29,20 @@ func (t *Transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 	if err != nil {
 		return nil, err
 	}
-	defer tmpFile.Close()
-	t.buffer = tmpFile
-	t.body = req.Body
+	t.bufferName = tmpFile.Name()
+	t.mutex = &sync.Mutex{}
+	t.closed = false
+
+	go func() {
+		defer tmpFile.Close()
+
+		tee := io.TeeReader(req.Body, tmpFile)
+		_, err := ioutil.ReadAll(tee)
+		t.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
 
 	if t.Transport == nil {
 		t.Transport = &http.Transport{}
@@ -42,10 +54,27 @@ func (t *Transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 }
 
 func (t *Transport) tries(req *http.Request) (*http.Response, error) {
-	bodyReader, err := newBodyReader(t.body, t.buffer)
+	res, err := t.runRequest(req)
+
+	if err != nil || res.StatusCode/100 != 2 {
+		if t.retries < t.MaxRetries {
+			time.Sleep(t.SleepDuration)
+			t.retries += 1
+			return t.tries(req)
+		}
+	} else {
+		t.retries = 0
+	}
+	return res, err
+}
+
+func (t *Transport) runRequest(req *http.Request) (*http.Response, error) {
+	var statusCode int
+	bodyReader, err := t.newBodyReader()
 	if err != nil {
 		return nil, err
 	}
+
 	newReq, err := http.NewRequest(req.Method, req.URL.String(), bodyReader)
 	newReq.Header = req.Header
 
@@ -55,7 +84,7 @@ func (t *Transport) tries(req *http.Request) (*http.Response, error) {
 		req.URL,
 	)
 	res, err := t.Transport.RoundTrip(newReq)
-	var statusCode int
+	newReq.Body.Close()
 	if res != nil {
 		statusCode = res.StatusCode
 	}
@@ -66,37 +95,43 @@ func (t *Transport) tries(req *http.Request) (*http.Response, error) {
 		err,
 		statusCode,
 	)
-	newReq.Body.Close()
-
-	if err != nil || statusCode/100 != 2 {
-		if t.retries < t.MaxRetries {
-			time.Sleep(t.SleepDuration)
-			t.retries += 1
-			return t.tries(newReq)
-		}
-	} else {
-		t.retries = 0
-	}
 	return res, err
 }
 
-func newBodyReader(streamer io.Reader, buffer *os.File) (io.ReadCloser, error) {
-	data, err := readBuffer(buffer)
+func (t *Transport) newBodyReader() (io.ReadCloser, error) {
+	reader, err := os.Open(t.bufferName)
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.NopCloser(io.MultiReader(data, io.TeeReader(streamer, buffer))), nil
+	return &bodyReader{reader, t}, nil
 }
 
-func readBuffer(b *os.File) (*bytes.Buffer, error) {
-	f, err := os.Open(b.Name())
-	if err != nil {
-		return nil, err
+func (t *Transport) Close() error {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	t.closed = true
+	return nil
+}
+func (t *Transport) isClosed() bool {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	return t.closed
+}
+
+type bodyReader struct {
+	io.ReadCloser
+	t *Transport
+}
+
+func (b *bodyReader) Read(p []byte) (int, error) {
+	for {
+		i, err := b.ReadCloser.Read(p)
+		if err == io.EOF && !b.t.isClosed() {
+			err = nil
+		}
+
+		if i > 0 || err != nil {
+			return i, err
+		}
 	}
-	defer f.Close()
-	d, err := ioutil.ReadAll(f)
-	if err != nil {
-		return nil, err
-	}
-	return bytes.NewBuffer(d), err
 }

--- a/busltee/transport.go
+++ b/busltee/transport.go
@@ -31,7 +31,6 @@ func (t *Transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 	}
 	t.bufferName = tmpFile.Name()
 	t.mutex = &sync.Mutex{}
-	t.closed = false
 
 	go func() {
 		defer tmpFile.Close()

--- a/example/compile
+++ b/example/compile
@@ -1,6 +1,8 @@
 #!/bin/bash
+
+SLEEP_TIME=${1:-1}
 for i in {1..600}
 do
   echo $i
-  sleep 1
+  sleep $SLEEP_TIME
 done

--- a/example/slow.sh
+++ b/example/slow.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+STREAM_ID=$(uuidgen)
+URL=http://$BUSL_HOST/streams/$STREAM_ID
+
+echo "Creating a stream"
+curl $URL -X PUT
+
+echo "Publishing to the stream"
+(go run cmd/busltee/main.go $URL -- ./example/compile 60 > log/command.log) &
+
+echo "Listening $i"
+curl $URL


### PR DESCRIPTION
This changes the body reader approach to avoid blocking issues.
The following is now being done:

* When we start the transport, we use a `TeeReader` to send all output to a temp file.
* Each connection opens and reads that file, ignoring EOF if the streaming isn't over.
* When reconnecting, we just reopen the same file again.

The previous issue was that reading and sending directly to the connection causes issues when we get a disconnection but `Read` is blocked, as we can't listen on `stdin` twice.
By writing stdin to a file, we can then read it multiple times without any worry about blocks.

This has been confirmed to fix the issue where a build which doesn't send any content for a while ends up not sending the data when it receives it.