### PR TITLE
Redis connections leak

### DIFF
--- a/broker/redis.go
+++ b/broker/redis.go
@@ -15,19 +15,19 @@ import (
 var (
 	redisURL           = flag.String("redisUrl", os.Getenv("REDIS_URL"), "URL of the redis server")
 	redisServer        *url.URL
-	redisPool          *Pool
+	redisPool          *pool
 	redisKeyExpire     = 60 // redis uses seconds for EXPIRE
 	redisChannelExpire = redisKeyExpire * 60
 )
 
-type Pool struct {
+type pool struct {
 	*redis.Pool
 
 	mu *sync.Mutex
 	c  int64
 }
 
-func (p *Pool) Get() Conn {
+func (p *pool) Get() Conn {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -38,7 +38,7 @@ func (p *Pool) Get() Conn {
 
 type Conn struct {
 	redis.Conn
-	p *Pool
+	p *pool
 }
 
 func (c Conn) Close() error {
@@ -59,11 +59,11 @@ func init() {
 	defer conn.Close()
 }
 
-func newPool(server *url.URL) *Pool {
+func newPool(server *url.URL) *pool {
 	cleanServerURL := *server
 	cleanServerURL.User = nil
 	log.Printf("connecting to redis: %s", cleanServerURL.String())
-	pool := &redis.Pool{
+	p := &redis.Pool{
 		MaxIdle:     3,
 		IdleTimeout: 4 * time.Minute,
 		Dial: func() (c redis.Conn, err error) {
@@ -93,7 +93,7 @@ func newPool(server *url.URL) *Pool {
 		},
 	}
 
-	return &Pool{pool, &sync.Mutex{}, 0}
+	return &pool{p, &sync.Mutex{}, 0}
 }
 
 type channel string

--- a/broker/redis.go
+++ b/broker/redis.go
@@ -23,13 +23,13 @@ var (
 type Pool struct {
 	*redis.Pool
 
-	m *sync.Mutex
-	c int
+	mu *sync.Mutex
+	c  int
 }
 
 func (p *Pool) Get() Conn {
-	p.m.Lock()
-	defer p.m.Unlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	p.c += 1
 	util.CountWithData("redis.conn.get", 1, "conn_count=%d, caller=%q#%d", p.c)
@@ -42,8 +42,8 @@ type Conn struct {
 }
 
 func (c Conn) Close() error {
-	c.p.m.Lock()
-	defer c.p.m.Unlock()
+	c.p.mu.Lock()
+	defer c.p.mu.Unlock()
 
 	c.p.c -= 1
 	util.CountWithData("redis.conn.release", 1, "conn_count=%d", c.p.c)

--- a/encoders/encoder.go
+++ b/encoders/encoder.go
@@ -1,0 +1,9 @@
+package encoders
+
+import "io"
+
+type Encoder interface {
+	io.Reader
+	io.Closer
+	io.Seeker
+}

--- a/encoders/reader_test.go
+++ b/encoders/reader_test.go
@@ -11,7 +11,7 @@ func (r *readSeekerCloser) Close() error {
 }
 
 type limitedReadCloser struct {
-	io.LimitedReader
+	*io.LimitedReader
 }
 
 func (r *limitedReadCloser) Close() error {

--- a/encoders/reader_test.go
+++ b/encoders/reader_test.go
@@ -1,0 +1,19 @@
+package encoders
+
+import "io"
+
+type readSeekerCloser struct {
+	io.ReadSeeker
+}
+
+func (r *readSeekerCloser) Close() error {
+	return nil
+}
+
+type limitedReadCloser struct {
+	io.LimitedReader
+}
+
+func (r *limitedReadCloser) Close() error {
+	return nil
+}

--- a/encoders/sse.go
+++ b/encoders/sse.go
@@ -13,17 +13,17 @@ const (
 )
 
 type sseEncoder struct {
-	reader io.Reader // stores the original reader
-	offset int64     // offset for Seek purposes
+	io.ReadCloser       // stores the original reader
+	offset        int64 // offset for Seek purposes
 }
 
 // NewSSEEncoder creates a new server-sent event encoder
-func NewSSEEncoder(r io.Reader) io.ReadSeeker {
-	return &sseEncoder{reader: r}
+func NewSSEEncoder(r io.ReadCloser) Encoder {
+	return &sseEncoder{ReadCloser: r}
 }
 
 func (r *sseEncoder) Seek(offset int64, whence int) (n int64, err error) {
-	if seeker, ok := r.reader.(io.ReadSeeker); ok {
+	if seeker, ok := r.ReadCloser.(io.ReadSeeker); ok {
 		r.offset, err = seeker.Seek(offset, whence)
 	} else {
 		// The underlying reader doesn't support seeking, but
@@ -43,7 +43,7 @@ func (r *sseEncoder) Seek(offset int64, whence int) (n int64, err error) {
 // that len(p) is always greater than the potential
 // length of data to be read.
 func (r *sseEncoder) Read(p []byte) (n int, err error) {
-	n, err = r.reader.Read(p)
+	n, err = r.ReadCloser.Read(p)
 
 	if n > 0 {
 		buf := format(r.offset, p[:n])

--- a/encoders/sse_test.go
+++ b/encoders/sse_test.go
@@ -30,7 +30,7 @@ var (
 
 func TestSSENoNewline(t *testing.T) {
 	for _, data := range testSSEData {
-		r := strings.NewReader(data.input)
+		r := &readSeekerCloser{strings.NewReader(data.input)}
 		enc := NewSSEEncoder(r)
 		enc.Seek(data.offset, 0)
 		assert.Equal(t, data.output, readstring(enc))
@@ -41,11 +41,11 @@ func TestSSENonSeekableReader(t *testing.T) {
 	// Seek the underlying reader before
 	// passing to LimitReader: comparably similar
 	// to scenario when reading from an http.Response
-	r := strings.NewReader("hello world")
+	r := &readSeekerCloser{strings.NewReader("hello world")}
 	r.Seek(10, 0)
 
 	// Use LimitReader to hide the Seeker interface
-	lr := io.LimitReader(r, 11)
+	lr := &limitedReadCloser{io.LimitedReader{r, 11}}
 
 	enc := NewSSEEncoder(lr)
 	enc.Seek(10, io.SeekStart)

--- a/encoders/sse_test.go
+++ b/encoders/sse_test.go
@@ -45,7 +45,7 @@ func TestSSENonSeekableReader(t *testing.T) {
 	r.Seek(10, 0)
 
 	// Use LimitReader to hide the Seeker interface
-	lr := &limitedReadCloser{io.LimitedReader{r, 11}}
+	lr := &limitedReadCloser{io.LimitReader(r, 11).(*io.LimitedReader)}
 
 	enc := NewSSEEncoder(lr)
 	enc.Seek(10, io.SeekStart)

--- a/encoders/text.go
+++ b/encoders/text.go
@@ -6,17 +6,17 @@ import (
 )
 
 type textEncoder struct {
-	io.Reader       // stores the original reader
-	offset    int64 // offset for Seek purposes
+	io.ReadCloser       // stores the original reader
+	offset        int64 // offset for Seek purposes
 }
 
 // NewTextEncoder creates a text events encoder
-func NewTextEncoder(r io.Reader) io.ReadSeeker {
-	return &textEncoder{Reader: r}
+func NewTextEncoder(r io.ReadCloser) Encoder {
+	return &textEncoder{ReadCloser: r}
 }
 
 func (r *textEncoder) Seek(offset int64, whence int) (n int64, err error) {
-	if seeker, ok := r.Reader.(io.ReadSeeker); ok {
+	if seeker, ok := r.ReadCloser.(io.ReadSeeker); ok {
 		r.offset, err = seeker.Seek(offset, whence)
 	} else {
 		// The underlying reader doesn't support seeking, but

--- a/encoders/text_test.go
+++ b/encoders/text_test.go
@@ -44,7 +44,7 @@ func TestTextNonSeekableReader(t *testing.T) {
 	r.Seek(10, 0)
 
 	// Use LimitReader to hide the Seeker interface
-	lr := &limitedReadCloser{io.LimitedReader{r, 11}}
+	lr := &limitedReadCloser{io.LimitReader(r, 11).(*io.LimitedReader)}
 
 	enc := NewTextEncoder(lr)
 	enc.Seek(10, 0)

--- a/encoders/text_test.go
+++ b/encoders/text_test.go
@@ -29,7 +29,7 @@ var (
 
 func TestTextNoNewline(t *testing.T) {
 	for _, data := range testTextData {
-		r := strings.NewReader(data.input)
+		r := &readSeekerCloser{strings.NewReader(data.input)}
 		enc := NewTextEncoder(r)
 		enc.Seek(data.offset, 0)
 		assert.Equal(t, data.output, readstring(enc))
@@ -40,11 +40,11 @@ func TestTextNonSeekableReader(t *testing.T) {
 	// Seek the underlying reader before
 	// passing to LimitReader: comparably similar
 	// to scenario when reading from an http.Response
-	r := strings.NewReader("hello world")
+	r := &readSeekerCloser{strings.NewReader("hello world")}
 	r.Seek(10, 0)
 
 	// Use LimitReader to hide the Seeker interface
-	lr := io.LimitReader(r, 11)
+	lr := &limitedReadCloser{io.LimitedReader{r, 11}}
 
 	enc := NewTextEncoder(lr)
 	enc.Seek(10, 0)

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
@@ -155,7 +154,7 @@ func (s *Server) newReader(w http.ResponseWriter, r *http.Request) (io.ReadClose
 		return nil, errNoContent
 	}
 
-	var encoder io.ReadSeeker
+	var encoder encoders.Encoder
 	if r.Header.Get("Accept") == "text/event-stream" {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")
@@ -168,12 +167,10 @@ func (s *Server) newReader(w http.ResponseWriter, r *http.Request) (io.ReadClose
 	} else {
 		encoder = encoders.NewTextEncoder(rd)
 	}
-
 	encoder.Seek(o, io.SeekStart)
-	rd = ioutil.NopCloser(encoder)
 
 	done := w.(http.CloseNotifier).CloseNotify()
-	return newKeepAliveReader(rd, ack, s.HeartbeatDuration, done), nil
+	return newKeepAliveReader(encoder, ack, s.HeartbeatDuration, done), nil
 }
 
 func storeOutput(channel string, requestURI string, storageBase string) {

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -147,10 +147,12 @@ func (s *Server) newReader(w http.ResponseWriter, r *http.Request) (io.ReadClose
 
 	o, err := offset(r)
 	if err != nil {
+		rd.Close()
 		return nil, err
 	}
 
 	if broker.NoContent(rd, o) {
+		rd.Close()
 		return nil, errNoContent
 	}
 

--- a/util/metrics.go
+++ b/util/metrics.go
@@ -19,3 +19,13 @@ func CountWithData(metric string, count int64, extraData string, v ...interface{
 		log.Printf("count#%s=%d %s", metric, count, fmt.Sprintf(extraData, v...))
 	}
 }
+
+func Sample(metric string, value int64) { SampleWithData(metric, value, "") }
+
+func SampleWithData(metric string, value int64, extraData string, v ...interface{}) {
+	if extraData == "" {
+		log.Printf("sample#%s=%d", metric, value)
+	} else {
+		log.Printf("sample#%s=%d %s", metric, value, fmt.Sprintf(extraData, v...))
+	}
+}


### PR DESCRIPTION
We cannot use `NopCloser` on readers, as it would nullify the `Close` method, and we would never release the redis connection.