### PR TITLE
Vary storage by host

### DIFF
--- a/cmd/busl/main.go
+++ b/cmd/busl/main.go
@@ -62,11 +62,15 @@ func parseFlags() (*cmdConfig, *server.Config, error) {
 	httpConf.Credentials = os.Getenv("CREDS")
 	httpConf.EnforceHTTPS = os.Getenv("ENFORCE_HTTPS") == "1"
 	flag.DurationVar(&httpConf.HeartbeatDuration, "subscribeHeartbeatDuration", time.Second*10, "Heartbeat interval for HTTP stream subscriptions.")
-	httpConf.StorageBaseURL = func() string { return os.Getenv("STORAGE_BASE_URL") }
+	httpConf.StorageBaseURL = getStorageBaseURL
 
 	flag.Parse()
 
 	return cmdConf, httpConf, nil
+}
+
+func getStorageBaseURL() string {
+	return os.Getenv("STORAGE_BASE_URL")
 }
 
 func awaitSignals(signals ...os.Signal) <-chan struct{} {

--- a/cmd/busl/main.go
+++ b/cmd/busl/main.go
@@ -7,13 +7,17 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"regexp"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/heroku/busl/server"
 	"github.com/heroku/rollbar"
 )
+
+var nonWordCharacters = regexp.MustCompile(`\W`)
 
 type cmdConfig struct {
 	RollbarEnvironment string
@@ -70,7 +74,12 @@ func parseFlags() (*cmdConfig, *server.Config, error) {
 	return cmdConf, httpConf, nil
 }
 
-func getStorageBaseURL(*http.Request) string {
+func getStorageBaseURL(r *http.Request) string {
+	prefix := strings.ToUpper(nonWordCharacters.ReplaceAllString(r.Host, "_"))
+	if v := os.Getenv(fmt.Sprintf("%v_STORAGE_BASE_URL", prefix)); v != "" {
+		return v
+	}
+
 	return os.Getenv("STORAGE_BASE_URL")
 }
 

--- a/cmd/busl/main.go
+++ b/cmd/busl/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
@@ -69,7 +70,7 @@ func parseFlags() (*cmdConfig, *server.Config, error) {
 	return cmdConf, httpConf, nil
 }
 
-func getStorageBaseURL() string {
+func getStorageBaseURL(*http.Request) string {
 	return os.Getenv("STORAGE_BASE_URL")
 }
 

--- a/cmd/busl/main.go
+++ b/cmd/busl/main.go
@@ -62,7 +62,7 @@ func parseFlags() (*cmdConfig, *server.Config, error) {
 	httpConf.Credentials = os.Getenv("CREDS")
 	httpConf.EnforceHTTPS = os.Getenv("ENFORCE_HTTPS") == "1"
 	flag.DurationVar(&httpConf.HeartbeatDuration, "subscribeHeartbeatDuration", time.Second*10, "Heartbeat interval for HTTP stream subscriptions.")
-	httpConf.StorageBaseURL = os.Getenv("STORAGE_BASE_URL")
+	httpConf.StorageBaseURL = func() string { return os.Getenv("STORAGE_BASE_URL") }
 
 	flag.Parse()
 

--- a/cmd/busl/main_test.go
+++ b/cmd/busl/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetStorageBaseURL(t *testing.T) {
+	os.Setenv("EXAMPLE_COM_STORAGE_BASE_URL", "https://example.s3.amazonaws.com/")
+	os.Setenv("STORAGE_BASE_URL", "default")
+
+	assert.Equal(t, "https://example.s3.amazonaws.com/",
+		getStorageBaseURL(&http.Request{Host: "example.com"}))
+	assert.Equal(t, "default",
+		getStorageBaseURL(&http.Request{Host: "localhost"}))
+	assert.Equal(t, "default",
+		getStorageBaseURL(&http.Request{}))
+}

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -82,7 +82,7 @@ func (s *Server) publish(w http.ResponseWriter, r *http.Request) {
 	util.CountWithData("server.pub.read.end", 1, "request_id=%q", r.Header.Get("Request-Id"))
 	writer.Close()
 	// Asynchronously upload the output to our defined storage backend.
-	go storeOutput(key(r), requestURI(r), s.StorageBaseURL)
+	go storeOutput(key(r), requestURI(r), s.StorageBaseURL())
 }
 
 func (s *Server) subscribe(w http.ResponseWriter, r *http.Request) {

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -82,7 +82,7 @@ func (s *Server) publish(w http.ResponseWriter, r *http.Request) {
 	util.CountWithData("server.pub.read.end", 1, "request_id=%q", r.Header.Get("Request-Id"))
 	writer.Close()
 	// Asynchronously upload the output to our defined storage backend.
-	go storeOutput(key(r), requestURI(r), s.StorageBaseURL())
+	go storeOutput(key(r), requestURI(r), s.StorageBaseURL(r))
 }
 
 func (s *Server) subscribe(w http.ResponseWriter, r *http.Request) {

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -121,7 +121,7 @@ func (s *Server) newStorageReader(w http.ResponseWriter, r *http.Request) (io.Re
 
 	// Not cached in the broker anymore, try the storage backend as a fallback.
 	if err == broker.ErrNotRegistered {
-		return storage.Get(requestURI(r), s.StorageBaseURL, o)
+		return storage.Get(requestURI(r), s.StorageBaseURL(), o)
 	}
 
 	if o > 0 {

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -121,7 +121,7 @@ func (s *Server) newStorageReader(w http.ResponseWriter, r *http.Request) (io.Re
 
 	// Not cached in the broker anymore, try the storage backend as a fallback.
 	if err == broker.ErrNotRegistered {
-		return storage.Get(requestURI(r), s.StorageBaseURL(), o)
+		return storage.Get(requestURI(r), s.StorageBaseURL(r), o)
 	}
 
 	if o > 0 {

--- a/server/server.go
+++ b/server/server.go
@@ -14,7 +14,7 @@ type Config struct {
 	EnforceHTTPS      bool
 	Credentials       string
 	HeartbeatDuration time.Duration
-	StorageBaseURL    string
+	StorageBaseURL    func() string
 }
 
 // Server is a launchable api listener

--- a/server/server.go
+++ b/server/server.go
@@ -14,7 +14,7 @@ type Config struct {
 	EnforceHTTPS      bool
 	Credentials       string
 	HeartbeatDuration time.Duration
-	StorageBaseURL    func() string
+	StorageBaseURL    func(*http.Request) string
 }
 
 // Server is a launchable api listener

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -19,7 +19,7 @@ var baseServer = NewServer(&Config{
 	EnforceHTTPS:      false,
 	Credentials:       "",
 	HeartbeatDuration: time.Second,
-	StorageBaseURL:    func() string { return "" },
+	StorageBaseURL:    func(*http.Request) string { return "" },
 })
 
 func Test410(t *testing.T) {
@@ -343,9 +343,9 @@ func TestSubGoneWithBackend(t *testing.T) {
 	storage, get, _ := fileServer(uuid)
 	defer storage.Close()
 
-	baseServer.StorageBaseURL = func() string { return storage.URL }
+	baseServer.StorageBaseURL = func(*http.Request) string { return storage.URL }
 	defer func() {
-		baseServer.StorageBaseURL = func() string { return "" }
+		baseServer.StorageBaseURL = func(*http.Request) string { return "" }
 	}()
 
 	server := httptest.NewServer(baseServer.router())
@@ -368,9 +368,9 @@ func TestPutWithBackend(t *testing.T) {
 	storage, _, put := fileServer(uuid)
 	defer storage.Close()
 
-	baseServer.StorageBaseURL = func() string { return storage.URL }
+	baseServer.StorageBaseURL = func(*http.Request) string { return storage.URL }
 	defer func() {
-		baseServer.StorageBaseURL = func() string { return "" }
+		baseServer.StorageBaseURL = func(*http.Request) string { return "" }
 	}()
 
 	server := httptest.NewServer(baseServer.router())

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -19,7 +19,7 @@ var baseServer = NewServer(&Config{
 	EnforceHTTPS:      false,
 	Credentials:       "",
 	HeartbeatDuration: time.Second,
-	StorageBaseURL:    "",
+	StorageBaseURL:    func() string { return "" },
 })
 
 func Test410(t *testing.T) {
@@ -343,9 +343,9 @@ func TestSubGoneWithBackend(t *testing.T) {
 	storage, get, _ := fileServer(uuid)
 	defer storage.Close()
 
-	baseServer.StorageBaseURL = storage.URL
+	baseServer.StorageBaseURL = func() string { return storage.URL }
 	defer func() {
-		baseServer.StorageBaseURL = ""
+		baseServer.StorageBaseURL = func() string { return "" }
 	}()
 
 	server := httptest.NewServer(baseServer.router())
@@ -368,9 +368,9 @@ func TestPutWithBackend(t *testing.T) {
 	storage, _, put := fileServer(uuid)
 	defer storage.Close()
 
-	baseServer.StorageBaseURL = storage.URL
+	baseServer.StorageBaseURL = func() string { return storage.URL }
 	defer func() {
-		baseServer.StorageBaseURL = ""
+		baseServer.StorageBaseURL = func() string { return "" }
 	}()
 
 	server := httptest.NewServer(baseServer.router())


### PR DESCRIPTION
If we set the descriptive `TEST_OUTPUT_HEROKU_COM_STORAGE_BASE_URL` configuration variable, this will allow @heroku/devex to retire their instance.