### PR TITLE
Stop reading the body once it has been closed

### DIFF
--- a/busltee/transport.go
+++ b/busltee/transport.go
@@ -144,8 +144,11 @@ type bodyReader struct {
 }
 
 func (b *bodyReader) Close() error {
-	b.closed = true
-	return b.ReadCloser.Close()
+	err := b.ReadCloser.Close()
+	if err == nil {
+		b.closed = true
+	}
+	return err
 }
 
 func (b *bodyReader) Read(p []byte) (int, error) {


### PR DESCRIPTION
We still looped through all entries in a body until that streamer finished all data.
Once a body has been closed, it means it's connection isn't open anymore, and we can stop reading.

Among a lot of disconnections, this could have caused latencies, as there were a lot of bodies open, all of which acquiring a lock on the mutex to know if they could close themselves or not.