### PR TITLE
Buffer the sse content in a byte array smaller than the one provided

### DIFF
--- a/encoders/sse.go
+++ b/encoders/sse.go
@@ -46,6 +46,10 @@ func (r *sseEncoder) Read(p []byte) (n int, err error) {
 
 	if n > 0 {
 		buf := format(r.offset, q[:n])
+		if len(buf) > len(p) {
+			return 0, errors.New("buffer length cannot be higher than bytes array")
+		}
+
 		r.offset += int64(n)
 		n = copy(p, buf)
 	}

--- a/encoders/sse.go
+++ b/encoders/sse.go
@@ -39,14 +39,13 @@ func (r *sseEncoder) Seek(offset int64, whence int) (n int64, err error) {
 	return r.offset, err
 }
 
-// FIXME: this version is simplified and assumes
-// that len(p) is always greater than the potential
-// length of data to be read.
 func (r *sseEncoder) Read(p []byte) (n int, err error) {
-	n, err = r.ReadCloser.Read(p)
+	// We assume SSE won't add more than twice the amount of data we get
+	q := make([]byte, len(p)/2)
+	n, err = r.ReadCloser.Read(q)
 
 	if n > 0 {
-		buf := format(r.offset, p[:n])
+		buf := format(r.offset, q[:n])
 		r.offset += int64(n)
 		n = copy(p, buf)
 	}


### PR DESCRIPTION
SSE adds data to the bytes array. Therefore, if the data we add goes over `len(p)`, some will be missed, and we won't serve it.
That causes invalid streams, which never get rendered by the dashboard.