### PR TITLE
Return an error if creating a stream failed

### DIFF
--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -17,8 +17,8 @@ func (s *Server) createStream(w http.ResponseWriter, r *http.Request) {
 
 	if err := registrar.Register(key(r)); err != nil {
 		http.Error(w, "Unable to create stream. Please try again.", http.StatusServiceUnavailable)
-		logError(r, err)
 		util.CountWithData("put.create.fail", 1, "error=%s", err)
+		handleError(w, r, err)
 		return
 	}
 	util.Count("put.create.success")

--- a/server/errors.go
+++ b/server/errors.go
@@ -49,7 +49,7 @@ func handleError(w http.ResponseWriter, r *http.Request, err error) {
 		w.WriteHeader(http.StatusNoContent)
 
 	default:
-		logError(req, err)
+		logError(r, err)
 		util.CountWithData("server.handleError", 1, "error=%s", err.Error())
 		w.WriteHeader(http.StatusInternalServerError)
 	}

--- a/server/errors.go
+++ b/server/errors.go
@@ -49,6 +49,7 @@ func handleError(w http.ResponseWriter, r *http.Request, err error) {
 		w.WriteHeader(http.StatusNoContent)
 
 	default:
+		logError(req, err)
 		util.CountWithData("server.handleError", 1, "error=%s", err.Error())
 		w.WriteHeader(http.StatusInternalServerError)
 	}


### PR DESCRIPTION
Right now, as we don't specify any HTTP status code, we'd return a 200.
This makes us return a 500, and notify all unexpected calls to `handleError` to rollbar.