### PR TITLE
Handle errors within IsRegistered

### DIFF
--- a/broker/io.go
+++ b/broker/io.go
@@ -21,7 +21,12 @@ var (
 
 // NewWriter creates a new redis channel writer
 func NewWriter(key string) (io.WriteCloser, error) {
-	if !NewRedisRegistrar().IsRegistered(key) {
+	r, err := NewRedisRegistrar().IsRegistered(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if !r {
 		return nil, ErrNotRegistered
 	}
 
@@ -66,7 +71,12 @@ type reader struct {
 
 // NewReader creates a new redis channel reader
 func NewReader(key string) (io.ReadCloser, error) {
-	if !NewRedisRegistrar().IsRegistered(key) {
+	r, err := NewRedisRegistrar().IsRegistered(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if !r {
 		return nil, ErrNotRegistered
 	}
 

--- a/broker/redis.go
+++ b/broker/redis.go
@@ -132,7 +132,7 @@ func (rr *RedisRegistrar) Register(channelName string) (err error) {
 }
 
 // IsRegistered checks whether a channel name is registered
-func (rr *RedisRegistrar) IsRegistered(channelName string) (registered bool) {
+func (rr *RedisRegistrar) IsRegistered(channelName string) (registered bool, err error) {
 	conn := redisPool.Get()
 	defer conn.Close()
 
@@ -141,10 +141,10 @@ func (rr *RedisRegistrar) IsRegistered(channelName string) (registered bool) {
 	exists, err := redis.Bool(conn.Do("EXISTS", channel.id()))
 	if err != nil {
 		util.CountWithData("RedisRegistrar.IsRegistered.error", 1, "error=%s", err)
-		return false
+		return false, err
 	}
 
-	return exists
+	return exists, nil
 }
 
 // Get returns a key value

--- a/broker/redis.go
+++ b/broker/redis.go
@@ -122,11 +122,9 @@ func (rr *RedisRegistrar) Register(channelName string) (err error) {
 	defer conn.Close()
 
 	channel := channel(channelName)
-
 	_, err = conn.Do("SETEX", channel.id(), redisChannelExpire, make([]byte, 0))
 	if err != nil {
 		util.CountWithData("RedisRegistrar.Register.error", 1, "error=%s", err)
-		return
 	}
 	return
 }
@@ -137,14 +135,11 @@ func (rr *RedisRegistrar) IsRegistered(channelName string) (registered bool, err
 	defer conn.Close()
 
 	channel := channel(channelName)
-
 	exists, err := redis.Bool(conn.Do("EXISTS", channel.id()))
 	if err != nil {
 		util.CountWithData("RedisRegistrar.IsRegistered.error", 1, "error=%s", err)
-		return false, err
 	}
-
-	return exists, nil
+	return exists, err
 }
 
 // Get returns a key value

--- a/broker/redis_test.go
+++ b/broker/redis_test.go
@@ -17,12 +17,17 @@ func newRegUUID() (*RedisRegistrar, string) {
 func TestRegisteredIsRegistered(t *testing.T) {
 	reg, uuid := newRegUUID()
 	reg.Register(uuid)
-	assert.True(t, reg.IsRegistered(uuid))
+
+	r, err := reg.IsRegistered(uuid)
+	assert.Nil(t, err)
+	assert.True(t, r)
 }
 
 func TestUnregisteredIsNotRegistered(t *testing.T) {
 	reg, uuid := newRegUUID()
-	assert.False(t, reg.IsRegistered(uuid))
+	r, err := reg.IsRegistered(uuid)
+	assert.Nil(t, err)
+	assert.False(t, r)
 }
 
 func TestUnregisteredErrNotRegistered(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -334,7 +334,9 @@ func TestPut(t *testing.T) {
 	assert.Equal(t, resp.StatusCode, http.StatusCreated)
 
 	registrar := broker.NewRedisRegistrar()
-	assert.True(t, registrar.IsRegistered("1/2/3"))
+	r, err := registrar.IsRegistered("1/2/3")
+	assert.Nil(t, err)
+	assert.True(t, r)
 }
 
 func TestSubGoneWithBackend(t *testing.T) {


### PR DESCRIPTION
If calling IsRegistered fails. Because the retrieved value isn't valid for example, we'd return false and silently ignore.

Such occurences are errors, and should be treated as such.