### PR TITLE
Add DELETE endpoint to close a stream

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -57,6 +57,7 @@ func (s *Server) router() http.Handler {
 
 	r.HandleFunc("/streams/{key:.+}", s.addDefaultHeaders(s.subscribe)).Methods("GET")
 	r.HandleFunc("/streams/{key:.+}", s.addDefaultHeaders(s.publish)).Methods("POST")
+	r.HandleFunc("/streams/{key:.+}", s.addDefaultHeaders(s.closeStream)).Methods("DELETE")
 	r.HandleFunc("/streams/{key:.+}", s.auth(s.addDefaultHeaders(s.createStream))).Methods("PUT")
 
 	return logRequest(s.enforceHTTPS(r.ServeHTTP))

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -460,3 +460,23 @@ func fileServer(id string) (*httptest.Server, chan []byte, chan []byte) {
 	server := httptest.NewServer(mux)
 	return server, get, put
 }
+
+func TestCloseStream(t *testing.T) {
+	server := httptest.NewServer(baseServer.router())
+	defer server.Close()
+
+	client := &http.Client{Transport: &http.Transport{}}
+
+	uuid, _ := util.NewUUID()
+	url := server.URL + "/streams/" + uuid
+	// curl -XPUT <url>/streams/<uuid>
+	request, _ := http.NewRequest("PUT", url, nil)
+	resp, err := client.Do(request)
+	assert.Nil(t, err)
+	defer resp.Body.Close()
+
+	req, _ := http.NewRequest("DELETE", server.URL+"/streams/"+uuid, nil)
+	r, err := client.Do(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, r.StatusCode)
+}


### PR DESCRIPTION
This endpoint allows us to close a stream without sending any new data to it.