### PR TITLE
Measure how long storing the output takes

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -183,6 +183,8 @@ func (s *Server) newReader(w http.ResponseWriter, r *http.Request) (io.ReadClose
 }
 
 func storeOutput(channel string, requestURI string, storageBase string) {
+	defer util.TimerEnd(util.TimerStart("server.storeOutput"))
+
 	if buf, err := broker.Get(channel); err == nil {
 		if err := storage.Put(requestURI, storageBase, bytes.NewBuffer(buf)); err != nil {
 			util.CountWithData("server.storeOutput.put.error", 1, "err=%s", err.Error())

--- a/util/metrics.go
+++ b/util/metrics.go
@@ -3,6 +3,8 @@ package util
 import (
 	"fmt"
 	"log"
+	"strings"
+	"time"
 )
 
 // Count parses a string into a count for logging to librato
@@ -28,4 +30,18 @@ func SampleWithData(metric string, value int64, extraData string, v ...interface
 	} else {
 		log.Printf("sample#busl.%s=%d %s", metric, value, fmt.Sprintf(extraData, v...))
 	}
+}
+
+func SMeasure(subject string, object string) string {
+	return fmt.Sprintf("measure#%s.%s=%s", prefix, subject, object)
+}
+
+func TimerStart(subject string, extras ...string) (time.Time, string, []string) {
+	log.Printf("%s.timer.start %s", subject, strings.Join(extras, " "))
+	return time.Now(), subject, extras
+}
+
+func TimerEnd(startTime time.Time, subject string, extras []string) {
+	elapsed := fmt.Sprintf("%f", time.Now().Sub(startTime).Seconds())
+	log.Printf("%s.timer.end %s %s", subject, SMeasure(subject+".elapsed.seconds", elapsed), strings.Join(extras, " "))
 }


### PR DESCRIPTION
We currently run this in a goroutine, meaning it can be killed within 10 seconds if the app needs to restart.
Measuring this will let us know if we need to better handle this, or if we're good with the current way for now.