### PR TITLE
Don't require a chunked transfer encoding to publish data

### DIFF
--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -30,11 +30,6 @@ func (s *Server) health(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) publish(w http.ResponseWriter, r *http.Request) {
-	if !util.StringInSlice(r.TransferEncoding, "chunked") {
-		http.Error(w, "A chunked Transfer-Encoding header is required.", http.StatusBadRequest)
-		return
-	}
-
 	writer, err := broker.NewWriter(key(r))
 	if err != nil {
 		handleError(w, r, err)


### PR DESCRIPTION
The request body will always be a reader.
So our interface will always work, whether there is a chunked transfer encoding or not.

While streaming data will always need chunked requests, we're starting to close streams with error messages coming from other components.
Those are static errors which don't make sense as chunked requests.