### PR TITLE
Avoid waiting indefinitely

### DIFF
--- a/busltee/runner.go
+++ b/busltee/runner.go
@@ -160,6 +160,7 @@ func run(args []string, stdout, stderr io.WriteCloser) error {
 	var copyErr error
 	select {
 	case copyErr = <-errCh:
+	case <-time.After(30 * time.Second):
 	}
 
 	if err != nil {


### PR DESCRIPTION
The 30 seconds matches [the usual dyno behavior](https://devcenter.heroku.com/articles/dynos#graceful-shutdown-with-sigterm).