### PR TITLE
Ignore `SIGPIPE`

### DIFF
--- a/busltee/runner.go
+++ b/busltee/runner.go
@@ -226,8 +226,17 @@ func deliverSignals(cmd *exec.Cmd) {
 	signal.Notify(sigc)
 	go func() {
 		s := <-sigc
-		logrus.WithFields(logrus.Fields{"busltee.signal.deliver": s}).Info("OK")
-		cmd.Process.Signal(s)
+
+		logrus.WithFields(logrus.Fields{
+			"signal": s,
+		}).Debug("received signal")
+
+		switch s {
+		case syscall.SIGPIPE:
+		default:
+			logrus.WithFields(logrus.Fields{"busltee.signal.deliver": s}).Info("OK")
+			cmd.Process.Signal(s)
+		}
 	}()
 }
 


### PR DESCRIPTION
I decided to ignore `SIGPIPE` because it's a signal sent to the process reading/writing from a broken pipe. Therefore it doesn't make sense to forward it to a child process.