### PR TITLE
Ignore `SIGCHLD`

### DIFF
--- a/busltee/runner.go
+++ b/busltee/runner.go
@@ -232,6 +232,7 @@ func deliverSignals(cmd *exec.Cmd) {
 		}).Debug("received signal")
 
 		switch s {
+		case syscall.SIGCHLD:
 		case syscall.SIGPIPE:
 		default:
 			logrus.WithFields(logrus.Fields{"busltee.signal.deliver": s}).Info("OK")


### PR DESCRIPTION
We receive the `SIGCHLD` signal when one of our child processes exit. That's not a signal we should propagate.