### PR TITLE
Write header on error

### DIFF
--- a/cmd/busl/main.go
+++ b/cmd/busl/main.go
@@ -36,9 +36,9 @@ func main() {
 	}
 
 	if cmdConf.RollbarToken != "" {
-		rollbar.Token = cmdConf.RollbarToken
-		rollbar.Environment = cmdConf.RollbarEnvironment
-		rollbar.ServerRoot = "github.com/heroku/busl"
+		rollbar.SetToken(cmdConf.RollbarToken)
+		rollbar.SetEnvironment(cmdConf.RollbarEnvironment)
+		rollbar.SetServerRoot("github.com/heroku/busl")
 	}
 
 	_, err = strconv.Atoi(cmdConf.HTTPPort)

--- a/cmd/busltee/main.go
+++ b/cmd/busltee/main.go
@@ -24,9 +24,9 @@ func main() {
 	}
 
 	if cmdConf.RollbarToken != "" {
-		rollbar.Token = cmdConf.RollbarToken
-		rollbar.Environment = cmdConf.RollbarEnvironment
-		rollbar.ServerRoot = "github.com/heroku/busl"
+		rollbar.SetToken(cmdConf.RollbarToken)
+		rollbar.SetEnvironment(cmdConf.RollbarEnvironment)
+		rollbar.SetServerRoot("github.com/heroku/busl")
 	}
 
 	busltee.ConfigureLogs(publisherConf.LogFile, cmdConf.LogFields)

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -56,6 +56,7 @@ func (s *Server) publish(w http.ResponseWriter, r *http.Request) {
 
 	if err == io.ErrUnexpectedEOF {
 		util.CountWithData("server.pub.read.eoferror", 1, "msg=%q request_id=%q", err, r.Header.Get("Request-Id"))
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 

--- a/vendor/github.com/heroku/rollbar/README.md
+++ b/vendor/github.com/heroku/rollbar/README.md
@@ -24,11 +24,11 @@ import (
 )
 
 func main() {
-  rollbar.Token = "MY_TOKEN"
-  rollbar.Environment = "production"                 // defaults to "development"
-  rollbar.CodeVersion = "v2"                         // optional Git hash/branch/tag (required for GitHub integration)
-  rollbar.ServerHost = "web.1"                       // optional override; defaults to hostname
-  rollbar.ServerRoot = "github.com/heroku/myproject" // path of project (required for GitHub integration and non-project stacktrace collapsing)
+  rollbar.SetToken("MY_TOKEN")
+  rollbar.SetEnvironment("production")                 // defaults to "development"
+  rollbar.SetCodeVersion("v2")                         // optional Git hash/branch/tag (required for GitHub integration)
+  rollbar.SetServerHost("web.1")                       // optional override; defaults to hostname
+  rollbar.SetServerRoot("github.com/heroku/myproject") // path of project (required for GitHub integration and non-project stacktrace collapsing)
 
   result, err := DoSomething()
   if err != nil {
@@ -59,3 +59,4 @@ A big thank you to everyone who has contributed pull requests and bug reports:
 * @kjk
 * @Soulou
 * @paulmach
+* @fabiokung

--- a/vendor/github.com/heroku/rollbar/client.go
+++ b/vendor/github.com/heroku/rollbar/client.go
@@ -1,0 +1,384 @@
+package rollbar
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"runtime"
+	"sync"
+	"time"
+)
+
+type Client interface {
+	io.Closer
+
+	// Rollbar access token.
+	SetToken(token string)
+	// All errors and messages will be submitted under this environment.
+	SetEnvironment(environment string)
+	// String describing the running code version on the server
+	SetCodeVersion(codeVersion string)
+	// host: The server hostname. Will be indexed.
+	SetServerHost(serverHost string)
+	// root: Path to the application code root, not including the final slash.
+	// Used to collapse non-project code when displaying tracebacks.
+	SetServerRoot(serverRoot string)
+	// custom: Any arbitrary metadata you want to send.
+	SetCustom(custom map[string]interface{})
+
+	// Rollbar access token.
+	GetToken() string
+	// All errors and messages will be submitted under this environment.
+	GetEnvironment() string
+	// String describing the running code version on the server
+	GetCodeVersion() string
+	// host: The server hostname. Will be indexed.
+	GetServerHost() string
+	// root: Path to the application code root, not including the final slash.
+	// Used to collapse non-project code when displaying tracebacks.
+	GetServerRoot() string
+	// custom: Any arbitrary metadata you want to send.
+	GetCustom() map[string]interface{}
+
+	// Error sends an error to Rollbar with the given severity level.
+	Error(level string, err error)
+	// ErrorWithExtras sends an error to Rollbar with the given severity
+	// level with extra custom data.
+	ErrorWithExtras(level string, err error, extras map[string]interface{})
+	// ErrorWithStackSkip sends an error to Rollbar with the given severity
+	// level and a given number of stack trace frames skipped.
+	ErrorWithStackSkip(level string, err error, skip int)
+	// ErrorWithStackSkipWithExtras sends an error to Rollbar with the given
+	// severity level and a given number of stack trace frames skipped with
+	// extra custom data.
+	ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{})
+
+	// RequestError sends an error to Rollbar with the given severity level
+	// and request-specific information.
+	RequestError(level string, r *http.Request, err error)
+	// RequestErrorWithExtras sends an error to Rollbar with the given
+	// severity level and request-specific information with extra custom data.
+	RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{})
+	// RequestErrorWithStackSkip sends an error to Rollbar with the given
+	// severity level and a given number of stack trace frames skipped, in
+	// addition to extra request-specific information.
+	RequestErrorWithStackSkip(level string, r *http.Request, err error, skip int)
+	// RequestErrorWithStackSkipWithExtras sends an error to Rollbar with
+	// the given severity level and a given number of stack trace frames
+	// skipped, in addition to extra request-specific information and extra
+	// custom data.
+	RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{})
+
+	// Message sends a message to Rollbar with the given severity level.
+	Message(level string, msg string)
+	// MessageWithExtras sends a message to Rollbar with the given severity
+	// level with extra custom data.
+	MessageWithExtras(level string, msg string, extras map[string]interface{})
+}
+
+// AsyncClient is the default concrete implementation of the Client interface
+// which sends all data to Rollbar asynchronously.
+type AsyncClient struct {
+	// Rollbar access token. If this is blank, no errors will be reported to
+	// Rollbar.
+	Token string
+	// All errors and messages will be submitted under this environment.
+	Environment string
+	// API endpoint for Rollbar.
+	Endpoint string
+	// Maximum number of errors allowed in the sending queue before we start
+	// dropping new errors on the floor.
+	Buffer int
+	// Filter HTTP Headers parameters from being sent to Rollbar.
+	FilterHeaders *regexp.Regexp
+	// Filter GET and POST parameters from being sent to Rollbar.
+	FilterFields *regexp.Regexp
+	// String describing the running code version on the server
+	CodeVersion string
+	// host: The server hostname. Will be indexed.
+	ServerHost string
+	// root: Path to the application code root, not including the final slash.
+	// Used to collapse non-project code when displaying tracebacks.
+	ServerRoot string
+	// custom: Any arbitrary metadata you want to send.
+	Custom map[string]interface{}
+	// Queue of messages to be sent.
+	bodyChannel chan map[string]interface{}
+	waitGroup   sync.WaitGroup
+}
+
+// New returns the default implementation of a Client
+func New(token, environment, codeVersion, serverHost, serverRoot string) Client {
+	return NewAsync(token, environment, codeVersion, serverHost, serverRoot)
+}
+
+// NewAsync builds an asynchronous implementation of the Client interface
+func NewAsync(token, environment, codeVersion, serverHost, serverRoot string) *AsyncClient {
+	buffer := 1000
+	client := &AsyncClient{
+		Token:         token,
+		Environment:   environment,
+		Endpoint:      "https://api.rollbar.com/api/1/item/",
+		Buffer:        1000,
+		FilterHeaders: regexp.MustCompile("Authorization"),
+		FilterFields:  regexp.MustCompile("password|secret|token"),
+		CodeVersion:   codeVersion,
+		ServerHost:    serverHost,
+		ServerRoot:    serverRoot,
+		bodyChannel:   make(chan map[string]interface{}, buffer),
+	}
+
+	go func() {
+		for body := range client.bodyChannel {
+			client.post(body)
+			client.waitGroup.Done()
+		}
+	}()
+	return client
+}
+
+func (c *AsyncClient) SetToken(token string) {
+	c.Token = token
+}
+
+func (c *AsyncClient) SetEnvironment(environment string) {
+	c.Environment = environment
+}
+
+func (c *AsyncClient) SetCodeVersion(codeVersion string) {
+	c.CodeVersion = codeVersion
+}
+
+func (c *AsyncClient) SetServerHost(serverHost string) {
+	c.ServerHost = serverHost
+}
+
+func (c *AsyncClient) SetServerRoot(serverRoot string) {
+	c.ServerRoot = serverRoot
+}
+
+func (c *AsyncClient) SetCustom(custom map[string]interface{}) {
+	c.Custom = custom
+}
+
+// -- Getters
+
+func (c *AsyncClient) GetToken() string {
+	return c.Token
+}
+
+func (c *AsyncClient) GetEnvironment() string {
+	return c.Environment
+}
+
+func (c *AsyncClient) GetCodeVersion() string {
+	return c.CodeVersion
+}
+
+func (c *AsyncClient) GetServerHost() string {
+	return c.ServerHost
+}
+
+func (c *AsyncClient) GetServerRoot() string {
+	return c.ServerRoot
+}
+
+func (c *AsyncClient) GetCustom() map[string]interface{} {
+	return c.Custom
+}
+
+// -- Error reporting
+
+var noExtras map[string]interface{}
+
+func (c *AsyncClient) Error(level string, err error) {
+	c.ErrorWithExtras(level, err, noExtras)
+}
+
+func (c *AsyncClient) ErrorWithExtras(level string, err error, extras map[string]interface{}) {
+	c.ErrorWithStackSkipWithExtras(level, err, 1, extras)
+}
+
+func (c *AsyncClient) RequestError(level string, r *http.Request, err error) {
+	c.RequestErrorWithExtras(level, r, err, noExtras)
+}
+
+func (c *AsyncClient) RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{}) {
+	c.RequestErrorWithStackSkipWithExtras(level, r, err, 1, extras)
+}
+
+func (c *AsyncClient) ErrorWithStackSkip(level string, err error, skip int) {
+	c.ErrorWithStackSkipWithExtras(level, err, skip, noExtras)
+}
+
+func (c *AsyncClient) ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{}) {
+	body := c.buildBody(level, err.Error(), extras)
+	data := body["data"].(map[string]interface{})
+	errBody, fingerprint := errorBody(err, skip)
+	data["body"] = errBody
+	data["fingerprint"] = fingerprint
+
+	c.push(body)
+}
+
+func (c *AsyncClient) RequestErrorWithStackSkip(level string, r *http.Request, err error, skip int) {
+	c.RequestErrorWithStackSkipWithExtras(level, r, err, skip, noExtras)
+}
+
+func (c *AsyncClient) RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
+	body := c.buildBody(level, err.Error(), extras)
+	data := body["data"].(map[string]interface{})
+
+	errBody, fingerprint := errorBody(err, skip)
+	data["body"] = errBody
+	data["fingerprint"] = fingerprint
+
+	data["request"] = c.errorRequest(r)
+
+	c.push(body)
+}
+
+// -- Message reporting
+
+func (c *AsyncClient) Message(level string, msg string) {
+	c.MessageWithExtras(level, msg, noExtras)
+}
+
+func (c *AsyncClient) MessageWithExtras(level string, msg string, extras map[string]interface{}) {
+	body := c.buildBody(level, msg, extras)
+	data := body["data"].(map[string]interface{})
+	data["body"] = messageBody(msg)
+
+	c.push(body)
+}
+
+// -- Misc.
+
+// wait will block until the queue of errors / messages is empty.
+func (c *AsyncClient) Wait() {
+	c.waitGroup.Wait()
+}
+
+// Close on the asynchronous Client is an alias to Wait
+func (c *AsyncClient) Close() error {
+	c.Wait()
+	return nil
+}
+
+// Build the main JSON structure that will be sent to Rollbar with the
+// appropriate metadata.
+func (c *AsyncClient) buildBody(level, title string, extras map[string]interface{}) map[string]interface{} {
+	timestamp := time.Now().Unix()
+
+	custom := c.Custom
+	for k, v := range extras {
+		custom[k] = v
+	}
+
+	data := map[string]interface{}{
+		"environment":  c.Environment,
+		"title":        title,
+		"level":        level,
+		"timestamp":    timestamp,
+		"platform":     runtime.GOOS,
+		"language":     "go",
+		"code_version": c.CodeVersion,
+		"server": map[string]interface{}{
+			"host": c.ServerHost,
+			"root": c.ServerRoot,
+		},
+		"notifier": map[string]interface{}{
+			"name":    NAME,
+			"version": VERSION,
+		},
+		"custom": custom,
+	}
+
+	return map[string]interface{}{
+		"access_token": c.Token,
+		"data":         data,
+	}
+}
+
+// Extract error details from a Request to a format that Rollbar accepts.
+func (c *AsyncClient) errorRequest(r *http.Request) map[string]interface{} {
+	cleanQuery := filterParams(c.FilterFields, r.URL.Query())
+
+	return map[string]interface{}{
+		"url":     r.URL.String(),
+		"method":  r.Method,
+		"headers": flattenValues(filterParams(c.FilterHeaders, r.Header)),
+
+		// GET params
+		"query_string": url.Values(cleanQuery).Encode(),
+		"GET":          flattenValues(cleanQuery),
+
+		// POST / PUT params
+		"POST": flattenValues(filterParams(c.FilterFields, r.Form)),
+	}
+}
+
+// filterParams filters sensitive information like passwords from being sent to
+// Rollbar.
+func filterParams(pattern *regexp.Regexp, values map[string][]string) map[string][]string {
+	for key, _ := range values {
+		if pattern.Match([]byte(key)) {
+			values[key] = []string{FILTERED}
+		}
+	}
+
+	return values
+}
+
+func flattenValues(values map[string][]string) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	for k, v := range values {
+		if len(v) == 1 {
+			result[k] = v[0]
+		} else {
+			result[k] = v
+		}
+	}
+
+	return result
+}
+
+// -- POST handling
+
+// Queue the given JSON body to be POSTed to Rollbar.
+func (c *AsyncClient) push(body map[string]interface{}) {
+	if len(c.bodyChannel) < c.Buffer {
+		c.waitGroup.Add(1)
+		c.bodyChannel <- body
+	} else {
+		rollbarError("buffer full, dropping error on the floor")
+	}
+}
+
+// POST the given JSON body to Rollbar synchronously.
+func (c *AsyncClient) post(body map[string]interface{}) {
+	if len(c.Token) == 0 {
+		rollbarError("empty token")
+		return
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		rollbarError("failed to encode payload: %s", err.Error())
+		return
+	}
+
+	resp, err := http.Post(c.Endpoint, "application/json", bytes.NewReader(jsonBody))
+	if err != nil {
+		rollbarError("POST failed: %s", err.Error())
+	} else if resp.StatusCode != 200 {
+		rollbarError("received response: %s", resp.Status)
+	}
+	if resp != nil {
+		resp.Body.Close()
+	}
+}

--- a/vendor/github.com/heroku/rollbar/rollbar.go
+++ b/vendor/github.com/heroku/rollbar/rollbar.go
@@ -1,25 +1,18 @@
 package rollbar
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"hash/adler32"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"reflect"
-	"regexp"
-	"runtime"
 	"strings"
-	"sync"
-	"time"
 )
 
 const (
 	NAME    = "heroku/rollbar"
-	VERSION = "0.3.0"
+	VERSION = "0.4.1"
 
 	// Severity levels
 	CRIT  = "critical"
@@ -32,119 +25,123 @@ const (
 )
 
 var (
-	// Rollbar access token. If this is blank, no errors will be reported to
-	// Rollbar.
-	Token = ""
-
-	// All errors and messages will be submitted under this environment.
-	Environment = "development"
-
-	// API endpoint for Rollbar.
-	Endpoint = "https://api.rollbar.com/api/1/item/"
-
-	// Maximum number of errors allowed in the sending queue before we start
-	// dropping new errors on the floor.
-	Buffer = 1000
-
-	// Filter HTTP Headers parameters from being sent to Rollbar.
-	FilterHeaders = regexp.MustCompile("Authorization")
-
-	// Filter GET and POST parameters from being sent to Rollbar.
-	FilterFields = regexp.MustCompile("password|secret|token")
-
-	// String describing the running code version on the server
-	CodeVersion = ""
-
-	// host: The server hostname. Will be indexed.
-	ServerHost, _ = os.Hostname()
-
-	// root: Path to the application code root, not including the final slash.
-	// Used to collapse non-project code when displaying tracebacks.
-	ServerRoot = ""
-
-	// Queue of messages to be sent.
-	bodyChannel chan map[string]interface{}
-	waitGroup   sync.WaitGroup
+	hostname, _ = os.Hostname()
+	std         = NewAsync("", "development", "", hostname, "")
 )
 
-// -- Setup
+// Rollbar access token.
+func SetToken(token string) {
+	std.SetToken(token)
+}
 
-func init() {
-	bodyChannel = make(chan map[string]interface{}, Buffer)
+// All errors and messages will be submitted under this environment.
+func SetEnvironment(environment string) {
+	std.SetEnvironment(environment)
+}
 
-	go func() {
-		for body := range bodyChannel {
-			post(body)
-			waitGroup.Done()
-		}
-	}()
+// String describing the running code version on the server
+func SetCodeVersion(codeVersion string) {
+	std.SetCodeVersion(codeVersion)
+}
+
+// host: The server hostname. Will be indexed.
+func SetServerHost(serverHost string) {
+	std.SetServerHost(serverHost)
+}
+
+// root: Path to the application code root, not including the final slash.
+// Used to collapse non-project code when displaying tracebacks.
+func SetServerRoot(serverRoot string) {
+	std.SetServerRoot(serverRoot)
+}
+
+// custom: Any arbitrary metadata you want to send.
+func SetCustom(custom map[string]interface{}) {
+	std.SetCustom(custom)
+}
+
+// -- Getters
+
+// Rollbar access token.
+func GetToken() string {
+	return std.GetToken()
+}
+
+// All errors and messages will be submitted under this environment.
+func GetEnvironment() string {
+	return std.GetEnvironment()
+}
+
+// String describing the running code version on the server
+func GetCodeVersion() string {
+	return std.GetCodeVersion()
+}
+
+// host: The server hostname. Will be indexed.
+func GetServerHost() string {
+	return std.GetServerHost()
+}
+
+// root: Path to the application code root, not including the final slash.
+// Used to collapse non-project code when displaying tracebacks.
+func GetServerRoot() string {
+	return std.GetServerRoot()
+}
+
+// custom: Any arbitrary metadata you want to send.
+func GetCustom() map[string]interface{} {
+	return std.GetCustom()
 }
 
 // -- Error reporting
 
-var noExtras map[string]interface{}
-
 // Error asynchronously sends an error to Rollbar with the given severity level.
 func Error(level string, err error) {
-	ErrorWithExtras(level, err, noExtras)
+	std.Error(level, err)
 }
 
-// Error asynchronously sends an error to Rollbar with the given severity level with extra custom data.
+// ErrorWithExtras asynchronously sends an error to Rollbar with the given
+// severity level with extra custom data.
 func ErrorWithExtras(level string, err error, extras map[string]interface{}) {
-	ErrorWithStackSkipWithExtras(level, err, 1, extras)
+	std.ErrorWithExtras(level, err, extras)
 }
 
 // RequestError asynchronously sends an error to Rollbar with the given
 // severity level and request-specific information.
 func RequestError(level string, r *http.Request, err error) {
-	RequestErrorWithExtras(level, r, err, noExtras)
+	std.RequestError(level, r, err)
 }
 
-// RequestError asynchronously sends an error to Rollbar with the given
+// RequestErrorWithExtras asynchronously sends an error to Rollbar with the given
 // severity level and request-specific information with extra custom data.
 func RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{}) {
-	RequestErrorWithStackSkipWithExtras(level, r, err, 1, extras)
+	std.RequestErrorWithExtras(level, r, err, extras)
 }
 
 // ErrorWithStackSkip asynchronously sends an error to Rollbar with the given
 // severity level and a given number of stack trace frames skipped.
 func ErrorWithStackSkip(level string, err error, skip int) {
-	ErrorWithStackSkipWithExtras(level, err, skip, noExtras)
+	std.ErrorWithStackSkip(level, err, skip)
 }
 
-// ErrorWithStackSkip asynchronously sends an error to Rollbar with the given
+// ErrorWithStackSkipWithExtras asynchronously sends an error to Rollbar with the given
 // severity level and a given number of stack trace frames skipped with extra custom data.
 func ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{}) {
-	body := buildBody(level, err.Error(), extras)
-	data := body["data"].(map[string]interface{})
-	errBody, fingerprint := errorBody(err, skip)
-	data["body"] = errBody
-	data["fingerprint"] = fingerprint
-
-	push(body)
+	std.ErrorWithStackSkipWithExtras(level, err, skip, extras)
 }
 
 // RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
 // given severity level and a given number of stack trace frames skipped, in
 // addition to extra request-specific information.
 func RequestErrorWithStackSkip(level string, r *http.Request, err error, skip int) {
-	RequestErrorWithStackSkipWithExtras(level, r, err, skip, noExtras)
+	std.RequestErrorWithStackSkip(level, r, err, skip)
 }
 
-// RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
-// given severity level and a given number of stack trace frames skipped, in
-// addition to extra request-specific information and extra custom data.
+// RequestErrorWithStackSkipWithExtras asynchronously sends an error to Rollbar
+// with the given severity level and a given number of stack trace frames skipped,
+// in addition to extra request-specific information and extra custom data.
 func RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
-	body := buildBody(level, err.Error(), extras)
-	data := body["data"].(map[string]interface{})
-
-	errBody, fingerprint := errorBody(err, skip)
-	data["body"] = errBody
-	data["fingerprint"] = fingerprint
-
-	data["request"] = errorRequest(r)
-
-	push(body)
+	std.RequestErrorWithStackSkipWithExtras(level, r, err, skip, extras)
 }
 
 // -- Message reporting
@@ -152,57 +149,21 @@ func RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err erro
 // Message asynchronously sends a message to Rollbar with the given severity
 // level. Rollbar request is asynchronous.
 func Message(level string, msg string) {
-	MessageWithExtras(level, msg, noExtras)
+	std.Message(level, msg)
 }
 
-// Message asynchronously sends a message to Rollbar with the given severity
+// MessageWithExtras asynchronously sends a message to Rollbar with the given severity
 // level with extra custom data. Rollbar request is asynchronous.
 func MessageWithExtras(level string, msg string, extras map[string]interface{}) {
-	body := buildBody(level, msg, extras)
-	data := body["data"].(map[string]interface{})
-	data["body"] = messageBody(msg)
-
-	push(body)
+	std.MessageWithExtras(level, msg, extras)
 }
-
-// -- Misc.
 
 // Wait will block until the queue of errors / messages is empty.
 func Wait() {
-	waitGroup.Wait()
+	std.Wait()
 }
 
-// Build the main JSON structure that will be sent to Rollbar with the
-// appropriate metadata.
-func buildBody(level, title string, extras map[string]interface{}) map[string]interface{} {
-	timestamp := time.Now().Unix()
-	data := map[string]interface{}{
-		"environment":  Environment,
-		"title":        title,
-		"level":        level,
-		"timestamp":    timestamp,
-		"platform":     runtime.GOOS,
-		"language":     "go",
-		"code_version": CodeVersion,
-		"server": map[string]interface{}{
-			"host": ServerHost,
-			"root": ServerRoot,
-		},
-		"notifier": map[string]interface{}{
-			"name":    NAME,
-			"version": VERSION,
-		},
-	}
-
-	for k, v := range extras {
-		data[k] = v
-	}
-
-	return map[string]interface{}{
-		"access_token": Token,
-		"data":         data,
-	}
-}
+// -- Misc.
 
 // Errors can implement this interface to create a trace_chain
 // Callers are required to call BuildStack on their own at the
@@ -266,50 +227,6 @@ func getOrBuildStack(err error, parent error, skip int) Stack {
 	return make(Stack, 0)
 }
 
-// Extract error details from a Request to a format that Rollbar accepts.
-func errorRequest(r *http.Request) map[string]interface{} {
-	cleanQuery := filterParams(FilterFields, r.URL.Query())
-
-	return map[string]interface{}{
-		"url":     r.URL.String(),
-		"method":  r.Method,
-		"headers": flattenValues(filterParams(FilterHeaders, r.Header)),
-
-		// GET params
-		"query_string": url.Values(cleanQuery).Encode(),
-		"GET":          flattenValues(cleanQuery),
-
-		// POST / PUT params
-		"POST": flattenValues(filterParams(FilterFields, r.Form)),
-	}
-}
-
-// filterParams filters sensitive information like passwords from being sent to
-// Rollbar.
-func filterParams(pattern *regexp.Regexp, values map[string][]string) map[string][]string {
-	for key, _ := range values {
-		if pattern.Match([]byte(key)) {
-			values[key] = []string{FILTERED}
-		}
-	}
-
-	return values
-}
-
-func flattenValues(values map[string][]string) map[string]interface{} {
-	result := make(map[string]interface{})
-
-	for k, v := range values {
-		if len(v) == 1 {
-			result[k] = v[0]
-		} else {
-			result[k] = v
-		}
-	}
-
-	return result
-}
-
 // Build a message inner-body for the given message string.
 func messageBody(s string) map[string]interface{} {
 	return map[string]interface{}{
@@ -328,42 +245,6 @@ func errorClass(err error) string {
 		return fmt.Sprintf("{%x}", checksum)
 	} else {
 		return strings.TrimPrefix(class, "*")
-	}
-}
-
-// -- POST handling
-
-// Queue the given JSON body to be POSTed to Rollbar.
-func push(body map[string]interface{}) {
-	if len(bodyChannel) < Buffer {
-		waitGroup.Add(1)
-		bodyChannel <- body
-	} else {
-		rollbarError("buffer full, dropping error on the floor")
-	}
-}
-
-// POST the given JSON body to Rollbar synchronously.
-func post(body map[string]interface{}) {
-	if len(Token) == 0 {
-		rollbarError("empty token")
-		return
-	}
-
-	jsonBody, err := json.Marshal(body)
-	if err != nil {
-		rollbarError("failed to encode payload: %s", err.Error())
-		return
-	}
-
-	resp, err := http.Post(Endpoint, "application/json", bytes.NewReader(jsonBody))
-	if err != nil {
-		rollbarError("POST failed: %s", err.Error())
-	} else if resp.StatusCode != 200 {
-		rollbarError("received response: %s", resp.Status)
-	}
-	if resp != nil {
-		resp.Body.Close()
 	}
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,10 +45,12 @@
 			"revision": "90765b9b92e3aef6da4b217586e9b64e0aee8378"
 		},
 		{
-			"checksumSHA1": "CD+EtSm6948GZ8+xmCRIZX8UcX0=",
-			"comment": "v0.3.0",
+			"checksumSHA1": "iYRTRvzmgdUbAMQVGmRj0ysK+KQ=",
 			"path": "github.com/heroku/rollbar",
-			"revision": "197e8a4fd165c96afe325b2297cf3bcaa5b9a6b4"
+			"revision": "aa40a4750d960d4173026078a04f2991b34d9442",
+			"revisionTime": "2015-02-17T20:28:13Z",
+			"version": "v0.4.2",
+			"versionExact": "v0.4.2"
 		},
 		{
 			"checksumSHA1": "C1k8Ky5xbqUBYMo6aesBq/yU2cQ=",


### PR DESCRIPTION
We correctly return to prevent closing the stream but it turns out the `status=200` could be a red herring.