### PR TITLE
Increase time-out

### DIFF
--- a/busltee/runner.go
+++ b/busltee/runner.go
@@ -45,7 +45,7 @@ func Run(url string, args []string, conf *Config) (exitCode int) {
 
 	select {
 	case <-done:
-	case <-time.After(time.Second):
+	case <-time.After(30 * time.Second):
 		logWithFields(logrus.Fields{"count#busltee.exec.upload.timeout": 1}).Warn()
 	}
 


### PR DESCRIPTION
This increases the time we try publishing a stream before timing out.

@benburkert discovered that the current time-out is the same time [we back off between stream retries](https://github.com/heroku/busl/blob/1b7fbe9ebc8de3eb74ca1a6e3f9a101f74a06191/busltee/transport.go#L63). That means an unfortunately timed error might prevent the stream closing properly.